### PR TITLE
[feat] 애플리케이션 실행 로그 파일로 저장되도록 로깅 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,3 +60,7 @@ jobs:
             docker rmi algoduck-app || true
             docker build -t algoduck-app .
             docker run -d -p 8080:8080 --name algoduck algoduck-app
+            
+            # 실패 여부 관계없이 로그 백업
+            sleep 5
+            docker logs algoduck > ~/algoduck-deploy.log || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM openjdk:17
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+
+# 로그 저장 디렉토리 지정
+WORKDIR /app
+
+# 애플리케이션 실행 시 로그가 /app/algoduck.log 로 기록됨
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -6,6 +6,7 @@ spring:
     url: ${DATASOURCE_URL}
     username: ${DB_USER_NAME}
     password: ${DB_PASSWORD}
+
   jpa:
     hibernate:
       ddl-auto: create
@@ -32,7 +33,10 @@ spring:
         profile_bucket: ${S3_PROFILE_BUCKET_NAME}
 
 logging:
+  file:
+    name: /app/algoduck.log  # ✅ 로그가 이 경로에 저장됨
   level:
+    root: INFO
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 


### PR DESCRIPTION
- Spring Boot 로그가 /app/algoduck.log에 저장되도록 application.yml 설정
- Dockerfile에서 로그 디렉토리 지정 및 로그 위치 고정
- GitHub Actions에서 docker logs를 EC2 ~/algoduck-deploy.log로 백업
- 실행 실패 시에도 로그 확인 가능해져 디버깅 편의성 향상