### PR TITLE
[bugfix] @Async 내에서 호출된 updateProfileImageUrl의 변경사항이 DB에 반영되지 않던 문제 해결

### DIFF
--- a/src/main/java/com/koreii/algoduck/member/repository/MemberRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/member/repository/MemberRepositoryJpaImpl.java
@@ -13,6 +13,7 @@ import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -176,9 +177,13 @@ public class MemberRepositoryJpaImpl implements MemberRepository {
   }
 
   @Override
+  @Transactional
   public MemberResponseDto updateProfileImageUrl(Long memberId, String profileImageUrl) {
     Member member = entityManager.find(Member.class, memberId);
     member.setProfileImageUrl(profileImageUrl);
+
+    log.info("DB에 프로필 이미지 업데이트 요청: memberId={}, url={}", memberId, profileImageUrl);
+
     return new MemberResponseDto(member);
   }
 


### PR DESCRIPTION
비동기 S3 업로드 완료 후 실행되는 thenAccept 블록 내부에서 memberRepository.updateProfileImageUrl()을 호출했지만, 해당 메서드에 @Transactional이 없어서 JPA 변경 감지가 동작하지 않아 DB에 profileImageUrl이 반영되지 않는 문제가 발생. 해결을 위해 updateProfileImageUrl에 @Transactional을 명시하여 변경사항이 커밋되도록 수정.