### PR TITLE
[feat] 소스코드 제출 시 S3 업로드 및 채점 결과 비동기 처리 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework:spring-test'
 
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'

--- a/src/main/java/com/koreii/algoduck/exceptions/file/submission/SubmissionFailureException.java
+++ b/src/main/java/com/koreii/algoduck/exceptions/file/submission/SubmissionFailureException.java
@@ -1,0 +1,18 @@
+package com.koreii.algoduck.exceptions.file.submission;
+
+public class SubmissionFailureException extends RuntimeException {
+  public SubmissionFailureException() {
+  }
+
+  public SubmissionFailureException(String message) {
+    super(message);
+  }
+
+  public SubmissionFailureException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public SubmissionFailureException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/com/koreii/algoduck/language/dto/response/LanguageResponseDto.java
+++ b/src/main/java/com/koreii/algoduck/language/dto/response/LanguageResponseDto.java
@@ -11,9 +11,11 @@ import lombok.Getter;
 public class LanguageResponseDto {
   private Long languageId;
   private String name;
+  private String extension;
 
   public LanguageResponseDto(Language language) {
     this.languageId = language.getLanguageId();
     this.name = language.getName();
+    this.extension = language.getExtension();
   }
 }

--- a/src/main/java/com/koreii/algoduck/language/entity/Language.java
+++ b/src/main/java/com/koreii/algoduck/language/entity/Language.java
@@ -31,4 +31,8 @@ public class Language extends BaseTimeEntity {
   @Column(nullable = false)
   @Setter
   private String name;
+
+  @Column(nullable = false)
+  @Setter
+  private String extension;
 }

--- a/src/main/java/com/koreii/algoduck/submission/dto/request/SubmissionUpdateRequestDto.java
+++ b/src/main/java/com/koreii/algoduck/submission/dto/request/SubmissionUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.koreii.algoduck.submission.dto.request;
 
+import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import com.koreii.algoduck.submission.enums.Status;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/koreii/algoduck/submission/dto/response/JudgeResponseDto.java
+++ b/src/main/java/com/koreii/algoduck/submission/dto/response/JudgeResponseDto.java
@@ -13,6 +13,6 @@ public class JudgeResponseDto {
   private String message;
   private String stdout;
   private String stderr;
-  private double executionTime;
-  private Long memoryUsage;
+  private Integer executionTime;
+  private Integer memoryUsage;
 }

--- a/src/main/java/com/koreii/algoduck/submission/service/JudgeService.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/JudgeService.java
@@ -1,6 +1,7 @@
 package com.koreii.algoduck.submission.service;
 
 import com.koreii.algoduck.submission.dto.request.JudgeRequestDto;
+import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.response.JudgeResponseDto;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/koreii/algoduck/submission/service/JudgeServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/JudgeServiceImpl.java
@@ -1,6 +1,7 @@
 package com.koreii.algoduck.submission.service;
 
 import com.koreii.algoduck.submission.dto.request.JudgeRequestDto;
+import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.response.JudgeResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
@@ -1,33 +1,106 @@
 package com.koreii.algoduck.submission.service;
 
-import com.koreii.algoduck.member.service.MemberService;
+import com.koreii.algoduck.exceptions.file.submission.SubmissionFailureException;
+import com.koreii.algoduck.file.FileStorageService;
 import com.koreii.algoduck.problem.dto.response.ProblemResponseDto;
 import com.koreii.algoduck.problem.service.ProblemService;
 import com.koreii.algoduck.submission.dto.request.JudgeRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionSaveRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionUpdateRequestDto;
+import com.koreii.algoduck.submission.dto.response.JudgeResponseDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import com.koreii.algoduck.submission.repository.SubmissionRepository;
 import com.koreii.algoduck.version.dto.response.VersionResponseDto;
 import com.koreii.algoduck.version.service.VersionService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SubmissionServiceImpl implements SubmissionService {
   private final VersionService versionService;
   private final ProblemService problemService;
   private final JudgeService judgeService;
   private final SubmissionRepository submissionRepository;
+  private final FileStorageService fileStorageService;
+
+  @Value("${spring.cloud.aws.s3.submission_bucket}")
+  private String bucketName;
+  private VersionResponseDto versionResponseDto;
 
   @Override
+  @Transactional
   public SubmissionResponseDto submission(SubmissionRequestDto submissionRequestDto) {
     ProblemResponseDto problemResponseDto = problemService.findDtoByProblemId(submissionRequestDto.getProblemId());
     VersionResponseDto versionResponseDto = versionService.findByVersionId(submissionRequestDto.getVersionId());
 
-    SubmissionResponseDto submissionResponseDto = submissionRepository.saveSubmission(new SubmissionSaveRequestDto(submissionRequestDto));
+    SubmissionSaveRequestDto submissionSaveRequestDto = new SubmissionSaveRequestDto(submissionRequestDto);
+    SubmissionResponseDto submissionResponseDto = submissionRepository.saveSubmission(submissionSaveRequestDto);
+
+    String sourceCode = submissionRequestDto.getSourceCode();
+    String codeName = problemResponseDto.getProblemNumber() + "." + versionResponseDto.getExtension();
+    Path tempFile = null;
+    MultipartFile multipartFile = null;
+
+    try {
+      tempFile = Files.createTempFile(codeName, "." + versionResponseDto.getExtension());
+      Files.write(tempFile, sourceCode.getBytes(StandardCharsets.UTF_8));
+      File file = tempFile.toFile();
+
+      try (FileInputStream fis = new FileInputStream(file)) {
+        multipartFile = new MockMultipartFile(
+            file.getName(),
+            file.getName(),
+            "text/plain",
+            fis
+        );
+      }
+
+      // 비동기 S3 업로드
+      CompletableFuture<String> uploadResult = fileStorageService.uploadFile(
+          bucketName,
+          "submission/" + submissionRequestDto.getProblemId(),
+          multipartFile
+      );
+
+      uploadResult.thenAccept(codeUrl -> {
+        SubmissionUpdateRequestDto updateDto = SubmissionUpdateRequestDto.builder()
+            .codeName(codeName)
+            .codeUrl(codeUrl)
+            .build();
+        updateSubmission(updateDto);
+      }).exceptionally(ex -> {
+        log.error("소스코드 업로드 실패", ex);
+        return null;
+      });
+
+    } catch (Exception e) {
+      log.error("{} 파일 업로드 실패 (소스코드 전송 실패)", codeName, e);
+      throw new SubmissionFailureException("소스코드 전송 실패", e);
+    } finally {
+      if (tempFile != null) {
+        try {
+          Files.deleteIfExists(tempFile);
+        } catch (IOException e) {
+          log.warn("임시 파일 삭제 실패: {}", tempFile, e);
+        }
+      }
+    }
 
     JudgeRequestDto judgeRequestDto = JudgeRequestDto.builder()
         .problemId(submissionRequestDto.getProblemId())
@@ -35,10 +108,23 @@ public class SubmissionServiceImpl implements SubmissionService {
         .version(versionResponseDto.getVersionName())
         .timeLimitation(problemResponseDto.getTimeLimitation())
         .memoryLimitation(problemResponseDto.getMemoryLimitation())
-        .sourceCode(submissionRequestDto.getSourceCode())
+        .sourceCode(sourceCode)
         .build();
 
-    judgeService.requestJudge(judgeRequestDto);
+    CompletableFuture<JudgeResponseDto> judgeResult = judgeService.requestJudge(judgeRequestDto);
+    judgeResult.thenAccept(judgeResponseDto -> {
+      SubmissionUpdateRequestDto submissionUpdateRequestDto = SubmissionUpdateRequestDto.builder()
+            .status(judgeResponseDto.getResult())
+            .message(judgeResponseDto.getMessage())
+            .executionTime(judgeResponseDto.getExecutionTime())
+            .memoryUsage(judgeResponseDto.getMemoryUsage())
+            .build();
+      updateSubmission(submissionUpdateRequestDto);
+    })
+        .exceptionally(ex -> {
+          log.error("채점 실패", ex);
+          return null;
+        });
 
     // 즉시 사용자에게 "채점 중" 메시지 반환
     return submissionResponseDto;
@@ -50,6 +136,7 @@ public class SubmissionServiceImpl implements SubmissionService {
   }
 
   @Override
+  @Transactional
   public SubmissionResponseDto updateSubmission(SubmissionUpdateRequestDto submissionUpdateRequestDto) {
     return submissionRepository.updateSubmission(submissionUpdateRequestDto);
   }

--- a/src/main/java/com/koreii/algoduck/version/dto/response/VersionResponseDto.java
+++ b/src/main/java/com/koreii/algoduck/version/dto/response/VersionResponseDto.java
@@ -11,11 +11,13 @@ import lombok.Getter;
 public class VersionResponseDto {
   private Long versionId;
   private String languageName;
+  private String extension;
   private String versionName;
 
   public VersionResponseDto(Version version) {
     this.versionId = version.getVersionId();
     this.languageName = version.getLanguage().getName();
+    this.extension = version.getLanguage().getExtension();
     this.versionName = version.getVersionName();
   }
 }


### PR DESCRIPTION
- 제출된 소스코드를 임시 파일로 저장하고 MultipartFile로 변환하여 S3에 비동기 업로드
- 업로드 완료 시 codeName, codeUrl을 submission 테이블에 갱신
- 채점 요청 또한 비동기 수행하며, 채점 결과를 DB에 반영
- 업로드/채점 중 예외 발생 시 오류 로그 기록 및 graceful degradation 처리
- Language/Version DTO에 확장자(extension) 필드 추가
- JudgeResponseDto에서 executionTime 타입을 double → Integer로 변경
- MockMultipartFile 사용을 위한 spring-test 의존성 추가