### PR TITLE
[feat] 커서 기반 페이징 적용 및 hasNext/hasPrev 포함한 제출 목록 API 구현

### DIFF
--- a/src/main/java/com/koreii/algoduck/base/dto/page/PageResponse.java
+++ b/src/main/java/com/koreii/algoduck/base/dto/page/PageResponse.java
@@ -1,0 +1,20 @@
+package com.koreii.algoduck.base.dto.page;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PageResponse<T> {
+  private boolean hasNext;
+  private boolean hasPrev;
+  private List<T> content;
+
+  public static <T> PageResponse<T> of(List<T> content, boolean hasNext, boolean hasPrev) {
+    return new PageResponse<>(hasNext, hasPrev, content);
+  }
+}

--- a/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
+++ b/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
@@ -1,0 +1,57 @@
+package com.koreii.algoduck.submission.controller;
+
+import com.koreii.algoduck.base.controller.BaseApiController;
+import com.koreii.algoduck.base.dto.page.PageResponse;
+import com.koreii.algoduck.base.dto.response.ApiResponse;
+import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
+import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
+import com.koreii.algoduck.submission.service.SubmissionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/submissions")
+@Tag(name = "Submission", description = "문제 제출 관련 API")
+@Slf4j
+public class SubmissionController extends BaseApiController {
+  private final SubmissionService submissionService;
+
+  @Operation(summary = "제출", description = "문제에 대한 코드를 제출합니다.")
+  @PostMapping
+  public ResponseEntity<ApiResponse<SubmissionResponseDto>> submit(SubmissionRequestDto submissionRequestDto) {
+    SubmissionResponseDto submissionResponseDto = submissionService.submit(submissionRequestDto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(submissionResponseDto));
+  }
+
+  // 첫 페이지 (lastSeenId 없이)
+  @GetMapping("/page")
+  public ResponseEntity<ApiResponse<PageResponse<SubmissionResponseDto>>> getPage(
+      @RequestParam(required = false) Long lastSeenId,
+      @RequestParam(required = false) Long firstSeenId,
+      @RequestParam(defaultValue = "20") int size
+  ) {
+    PageResponse<SubmissionResponseDto> page;
+
+    if (lastSeenId == null && firstSeenId == null) {
+      page = submissionService.getFirstPage(size);
+    } else if (lastSeenId != null) {
+      page = submissionService.getNextPage(lastSeenId, size);
+    } else {
+      page = submissionService.getPrevPage(firstSeenId, size);
+    }
+
+    return ResponseEntity.ok(ApiResponse.success(page));
+  }
+}

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepository.java
@@ -1,10 +1,13 @@
 package com.koreii.algoduck.submission.repository;
 
+import com.koreii.algoduck.base.dto.page.PageResponse;
 import com.koreii.algoduck.submission.dto.request.SubmissionSaveRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionUpdateRequestDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import com.koreii.algoduck.submission.entity.Submission;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface SubmissionRepository {
@@ -13,4 +16,8 @@ public interface SubmissionRepository {
   Submission findBySubmissionId(Long submissionId);
 
   SubmissionResponseDto updateSubmission(SubmissionUpdateRequestDto submissionUpdateRequestDto);
+
+  PageResponse<SubmissionResponseDto> findNextPage(Long lastSeenId, int pageSize);
+
+  PageResponse<SubmissionResponseDto> findPrevPage(Long firstSeenId, int pageSize);
 }

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -1,5 +1,6 @@
 package com.koreii.algoduck.submission.repository;
 
+import com.koreii.algoduck.base.dto.page.PageResponse;
 import com.koreii.algoduck.member.repository.MemberRepository;
 import com.koreii.algoduck.problem.repository.ProblemRepository;
 import com.koreii.algoduck.submission.dto.request.SubmissionSaveRequestDto;
@@ -11,6 +12,9 @@ import com.koreii.algoduck.version.repository.VersionRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -50,5 +54,46 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     submission.setExecutionTime(submissionUpdateRequestDto.getExecutionTime());
     submission.setMemoryUsage(submissionUpdateRequestDto.getMemoryUsage());
     return new SubmissionResponseDto(submission);
+  }
+
+  @Override
+  public PageResponse<SubmissionResponseDto> findNextPage(Long lastSeenId, int pageSize) {
+    String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
+        "FROM Submission s " +
+        "WHERE (:lastId IS NULL OR s.id < :lastId) " +
+        "ORDER BY s.id DESC";
+
+    List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
+        .setParameter("lastId", lastSeenId)
+        .setMaxResults(pageSize)
+        .getResultList();
+
+    boolean hasNext = result.size() > pageSize;
+    if (hasNext) {
+      result.remove(pageSize);
+    }
+
+    return PageResponse.of(result, hasNext, lastSeenId != null);
+  }
+
+  @Override
+  public PageResponse<SubmissionResponseDto> findPrevPage(Long firstSeenId, int pageSize) {
+    String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
+        "FROM Submission s " +
+        "WHERE s.id > :firstId " +
+        "ORDER BY s.id ASC";
+
+    List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
+        .setParameter("firstId", firstSeenId)
+        .setMaxResults(pageSize + 1)
+        .getResultList();
+
+    boolean hasPrev = result.size() > pageSize;
+    if (hasPrev) {
+      result.remove(pageSize);
+    }
+
+    Collections.reverse(result); // 최신순 유지
+    return PageResponse.of(result, true, hasPrev);
   }
 }

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
@@ -1,15 +1,26 @@
 package com.koreii.algoduck.submission.service;
 
+import com.koreii.algoduck.base.dto.page.PageResponse;
 import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionUpdateRequestDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public interface SubmissionService {
-  SubmissionResponseDto submission(SubmissionRequestDto submissionRequestDto);
+  SubmissionResponseDto submit(SubmissionRequestDto submissionRequestDto);
 
   SubmissionResponseDto findBySubmissionId(Long submissionId);
 
   SubmissionResponseDto updateSubmission(SubmissionUpdateRequestDto submissionUpdateRequestDto);
+
+  PageResponse<SubmissionResponseDto> getFirstPage(int pageSize);
+
+  // 다음 페이지 요청 (현재 마지막 ID 기준으로 다음 데이터 조회)
+  PageResponse<SubmissionResponseDto> getNextPage(Long lastSeenId, int pageSize);
+
+  // 이전 페이지 요청 (현재 첫 ID 기준으로 더 최신 데이터 조회)
+  PageResponse<SubmissionResponseDto> getPrevPage(Long firstSeenId, int pageSize);
 }

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
@@ -1,5 +1,6 @@
 package com.koreii.algoduck.submission.service;
 
+import com.koreii.algoduck.base.dto.page.PageResponse;
 import com.koreii.algoduck.exceptions.file.submission.SubmissionFailureException;
 import com.koreii.algoduck.file.FileStorageService;
 import com.koreii.algoduck.problem.dto.response.ProblemResponseDto;
@@ -45,7 +46,7 @@ public class SubmissionServiceImpl implements SubmissionService {
 
   @Override
   @Transactional
-  public SubmissionResponseDto submission(SubmissionRequestDto submissionRequestDto) {
+  public SubmissionResponseDto submit(SubmissionRequestDto submissionRequestDto) {
     ProblemResponseDto problemResponseDto = problemService.findDtoByProblemId(submissionRequestDto.getProblemId());
     VersionResponseDto versionResponseDto = versionService.findByVersionId(submissionRequestDto.getVersionId());
 
@@ -140,4 +141,23 @@ public class SubmissionServiceImpl implements SubmissionService {
   public SubmissionResponseDto updateSubmission(SubmissionUpdateRequestDto submissionUpdateRequestDto) {
     return submissionRepository.updateSubmission(submissionUpdateRequestDto);
   }
+
+  // 첫 페이지 (가장 최근 제출부터 시작)
+  @Override
+  public PageResponse<SubmissionResponseDto> getFirstPage(int pageSize) {
+    return submissionRepository.findNextPage(null, pageSize);
+  }
+
+  // 다음 페이지 요청 (현재 마지막 ID 기준으로 다음 데이터 조회)
+  @Override
+  public PageResponse<SubmissionResponseDto> getNextPage(Long lastSeenId, int pageSize) {
+    return submissionRepository.findNextPage(lastSeenId, pageSize);
+  }
+
+  // 이전 페이지 요청 (현재 첫 ID 기준으로 더 최신 데이터 조회)
+  @Override
+  public PageResponse<SubmissionResponseDto> getPrevPage(Long firstSeenId, int pageSize) {
+    return submissionRepository.findPrevPage(firstSeenId, pageSize);
+  }
+
 }


### PR DESCRIPTION
- SubmissionRepository에 커서 기반 페이징 메서드(findNextPage, findPrevPage) 추가
- PageResponse DTO 도입: hasNext, hasPrev, content 필드 포함
- SubmissionRepositoryJpaImpl에서 pageSize + 1 조회로 다음/이전 페이지 존재 여부 판단
- SubmissionService 및 구현체에서 페이징 메서드 위임 처리
- 첫 페이지, 이전/다음 페이지 조회 기능 제공

- 백준 제출현황처럼 '특정 페이지 이동 없이' 앞뒤로만 이동 가능한 페이징 방식 구현
- 프론트엔드가 이전/다음 버튼 활성 여부를 판단할 수 있도록 hasNext/hasPrev 정보 제공
- 무한스크롤 또는 버튼 기반 UI에 적합한 성능 효율적 페이징 구조 구현