### PR TITLE
[feat] 문제 상세 조회 시 공개 테스트케이스 포함 기능 추가

### DIFF
--- a/src/main/java/com/koreii/algoduck/problem/dto/response/ProblemResponseDto.java
+++ b/src/main/java/com/koreii/algoduck/problem/dto/response/ProblemResponseDto.java
@@ -1,12 +1,16 @@
 package com.koreii.algoduck.problem.dto.response;
 
 import com.koreii.algoduck.problem.entity.Problem;
+import com.koreii.algoduck.testcase.dto.response.TestcaseResponseDto;
 import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -21,6 +25,8 @@ public class ProblemResponseDto {
   private Integer difficulty;
   private Integer timeLimitation;
   private Integer memoryLimitation;
+  @Setter
+  private List<TestcaseResponseDto> testcaseResponseDtoList;
 
   public ProblemResponseDto(Problem problem) {
     this.problemId = problem.getProblemId();
@@ -32,5 +38,6 @@ public class ProblemResponseDto {
     this.difficulty = problem.getDifficulty();
     this.timeLimitation = problem.getTimeLimitation();
     this.memoryLimitation = problem.getMemoryLimitation();
+    this.testcaseResponseDtoList = new ArrayList<>();
   }
 }

--- a/src/main/java/com/koreii/algoduck/problem/service/ProblemServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/problem/service/ProblemServiceImpl.java
@@ -8,6 +8,7 @@ import com.koreii.algoduck.problem.entity.Problem;
 import com.koreii.algoduck.problem.repository.ProblemRepository;
 import com.koreii.algoduck.problemalgorithm.service.ProblemAlgorithmService;
 import com.koreii.algoduck.problemimage.service.ProblemImageService;
+import com.koreii.algoduck.testcase.dto.response.TestcaseResponseDto;
 import com.koreii.algoduck.testcase.repository.TestcaseRepository;
 import com.koreii.algoduck.testcase.service.TestcaseService;
 import lombok.RequiredArgsConstructor;
@@ -94,6 +95,10 @@ public class ProblemServiceImpl implements ProblemService {
 
   @Override
   public ProblemResponseDto findDtoByProblemId(Long problemId) {
-    return new ProblemResponseDto(findByProblemId(problemId));
+    ProblemResponseDto problemResponseDto = new ProblemResponseDto(findByProblemId(problemId));
+    List<TestcaseResponseDto> testcaseResponseDtos = testcaseService.selectPublicTestcasesByProblemId(problemId);
+    problemResponseDto.setTestcaseResponseDtoList(testcaseResponseDtos);
+
+    return problemResponseDto;
   }
 }

--- a/src/main/java/com/koreii/algoduck/testcase/repository/TestcaseRepository.java
+++ b/src/main/java/com/koreii/algoduck/testcase/repository/TestcaseRepository.java
@@ -16,4 +16,6 @@ public interface TestcaseRepository {
   Testcase findByTestcaseId(Long testcaseId);
 
   List<TestcaseResponseDto> selectTestcasesByProblemId(Long problemId);
+
+  List<TestcaseResponseDto> selectPublicTestcasesByProblemId(Long problemId);
 }

--- a/src/main/java/com/koreii/algoduck/testcase/repository/TestcaseRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/testcase/repository/TestcaseRepositoryJpaImpl.java
@@ -47,4 +47,15 @@ public class TestcaseRepositoryJpaImpl implements TestcaseRepository {
         .setParameter("problemId", problemId)
         .getResultList();
   }
+
+  @Override
+  public List<TestcaseResponseDto> selectPublicTestcasesByProblemId(Long problemId) {
+    String jpql = "SELECT new com.koreii.algoduck.testcase.dto.response.TestcaseResponseDto(t) "
+        + "FROM Testcase t "
+        + "WHERE t.problem.problemId = :problemId and t.isPublic = true";
+
+    return entityManager.createQuery(jpql, TestcaseResponseDto.class)
+        .setParameter("problemId", problemId)
+        .getResultList();
+  }
 }

--- a/src/main/java/com/koreii/algoduck/testcase/service/TestcaseService.java
+++ b/src/main/java/com/koreii/algoduck/testcase/service/TestcaseService.java
@@ -16,4 +16,6 @@ public interface TestcaseService {
   TestcaseResponseDto findByTestcaseId(Long testcaseId);
 
   List<TestcaseResponseDto> selectTestcasesByProblemId(Long problemId);
+
+  List<TestcaseResponseDto> selectPublicTestcasesByProblemId(Long problemId);
 }

--- a/src/main/java/com/koreii/algoduck/testcase/service/TestcaseServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/testcase/service/TestcaseServiceImpl.java
@@ -98,4 +98,9 @@ public class TestcaseServiceImpl implements TestcaseService {
   public List<TestcaseResponseDto> selectTestcasesByProblemId(Long problemId) {
     return testcaseRepository.selectTestcasesByProblemId(problemId);
   }
+
+  @Override
+  public List<TestcaseResponseDto> selectPublicTestcasesByProblemId(Long problemId) {
+    return testcaseRepository.selectPublicTestcasesByProblemId(problemId);
+  }
 }


### PR DESCRIPTION
- ProblemResponseDto에 testcaseResponseDtoList 필드 추가
- ProblemServiceImpl에서 문제 조회 시 공개 테스트케이스 조회 및 세팅
- TestcaseRepository에 selectPublicTestcasesByProblemId 메서드 정의 및 구현
- TestcaseService 인터페이스 및 구현체에 공개 테스트케이스 조회 메서드 추가