### PR TITLE
[bugfix] 같은 version_id로 제출 시 Duplicate entry 문제 해결

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/entity/Submission.java
+++ b/src/main/java/com/koreii/algoduck/submission/entity/Submission.java
@@ -58,7 +58,7 @@ public class Submission extends BaseTimeEntity {
   @Setter
   private String codeUrl;
 
-  @OneToOne
+  @ManyToOne
   @JoinColumn(name = "version_id", nullable = false)
   private Version version;
 


### PR DESCRIPTION
- Submission.version 필드의 관계를 @OneToOne → @ManyToOne으로 수정
- 하나의 Version이 여러 개의 Submission에서 참조될 수 있도록 관계 정의 변경
- JPA 연관 관계 오류 및 제약 위반 방지