### PR TITLE
[feat] 세션 로그인 상태 확인을 위한 /members/me API 추가 및 세션 타임아웃 설정

### DIFF
--- a/src/main/java/com/koreii/algoduck/member/controller/MemberController.java
+++ b/src/main/java/com/koreii/algoduck/member/controller/MemberController.java
@@ -5,20 +5,20 @@ import com.koreii.algoduck.base.dto.response.ApiResponse;
 import com.koreii.algoduck.member.dto.request.LoginRequestDto;
 import com.koreii.algoduck.member.dto.request.MemberSaveRequestDto;
 import com.koreii.algoduck.member.dto.request.MemberUpdateRequestDto;
-import com.koreii.algoduck.member.dto.response.MemberResponseDto;
 import com.koreii.algoduck.member.dto.response.MemberPagingResponseDto;
+import com.koreii.algoduck.member.dto.response.MemberResponseDto;
 import com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto;
 import com.koreii.algoduck.member.enums.Role;
 import com.koreii.algoduck.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -183,5 +183,16 @@ public class MemberController extends BaseApiController {
   public ResponseEntity<ApiResponse<Void>> logout(HttpServletRequest request) {
     memberService.logout(request);
     return ResponseEntity.ok(ApiResponse.success(null));
+  }
+
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<MemberResponseDto>> getMyInfo(HttpServletRequest request) {
+    HttpSession session = request.getSession(false);
+    MemberResponseDto memberResponseDto = memberService.getMyInfo(session);
+    if (memberResponseDto == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("세션이 만료되었습니다."));
+    }
+
+    return ResponseEntity.ok(ApiResponse.success(memberResponseDto));
   }
 }

--- a/src/main/java/com/koreii/algoduck/member/service/LoginService.java
+++ b/src/main/java/com/koreii/algoduck/member/service/LoginService.java
@@ -1,10 +1,23 @@
 package com.koreii.algoduck.member.service;
 
 import com.koreii.algoduck.member.dto.response.MemberResponseDto;
+import com.koreii.algoduck.member.entity.Member;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+import static com.koreii.algoduck.util.constants.Constants.LOGIN_MEMBER;
 
 public interface LoginService {
   MemberResponseDto login(String loginId, String password, HttpServletRequest request);
 
   void logout(HttpServletRequest request);
+
+  default MemberResponseDto getMyInfo(HttpSession session) {
+    if (session == null || session.getAttribute(LOGIN_MEMBER) == null) {
+      return null;
+    }
+
+    Member member = (Member) session.getAttribute(LOGIN_MEMBER);
+    return new MemberResponseDto(member);
+  }
 }

--- a/src/main/java/com/koreii/algoduck/member/service/MemberService.java
+++ b/src/main/java/com/koreii/algoduck/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.koreii.algoduck.member.dto.response.MemberResponseDto;
 import com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto;
 import com.koreii.algoduck.member.enums.Role;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -44,4 +45,6 @@ public interface MemberService {
   MemberResponseDto login(String loginId, String password, HttpServletRequest request);
 
   void logout(HttpServletRequest request);
+
+  MemberResponseDto getMyInfo(HttpSession session);
 }

--- a/src/main/java/com/koreii/algoduck/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/member/service/MemberServiceImpl.java
@@ -10,6 +10,7 @@ import com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto;
 import com.koreii.algoduck.member.enums.Role;
 import com.koreii.algoduck.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -199,5 +200,10 @@ public class MemberServiceImpl implements MemberService {
   @Override
   public void logout(HttpServletRequest request) {
     loginService.logout(request);
+  }
+
+  @Override
+  public MemberResponseDto getMyInfo(HttpSession session) {
+    return loginService.getMyInfo(session);
   }
 }

--- a/src/main/java/com/koreii/algoduck/member/service/SessionLoginServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/member/service/SessionLoginServiceImpl.java
@@ -30,7 +30,7 @@ public class SessionLoginServiceImpl implements LoginService {
 
     //  기존 세션이 있으면 사용, 없으면 새로 생성
     HttpSession session = request.getSession(true);
-
+    log.info("세션 유효시간 (초): " + session.getMaxInactiveInterval());
     //  세션에 로그인 회원 정보 저장
     session.setAttribute(LOGIN_MEMBER, member);
 

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -66,3 +66,8 @@ management:
     web:
       exposure:
         include: health,info
+
+server:
+  servlet:
+    session:
+      timeout: 30m


### PR DESCRIPTION
- 세션 유지 상태 확인을 위한 GET /members/me 엔드포인트 추가
- LoginService에 getMyInfo() 디폴트 메서드 구현
- MemberServiceImpl에서 로그인 상태 위임 처리
- application.yml에 세션 타임아웃 30분 명시