### PR TITLE
[bugfix] 채점 현황 페이지네이션에서 다음/이전 페이지 감지 정확도 향상

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -86,7 +86,7 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("lastId", lastSeenId)
-        .setMaxResults(pageSize)
+        .setMaxResults(pageSize + 1)
         .getResultList();
 
     boolean hasNext = result.size() > pageSize;
@@ -115,6 +115,6 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     }
 
     Collections.reverse(result); // 최신순 유지
-    return PageResponse.of(result, true, hasPrev);
+    return PageResponse.of(result, firstSeenId != null, hasPrev);
   }
 }


### PR DESCRIPTION
- findNextPage()에서 pageSize + 1개를 조회해 hasNext 판단 정확도 개선
- findPrevPage()에서 hasNext 값을 firstSeenId 여부로 대체하여 일관성 향상