### PR TITLE
[feat] 세션 기반 인증 전환 및 사용자 인증 객체 구성 리팩토링

### DIFF
--- a/src/main/java/com/koreii/algoduck/config/SpringSecurityConfig.java
+++ b/src/main/java/com/koreii/algoduck/config/SpringSecurityConfig.java
@@ -2,12 +2,17 @@ package com.koreii.algoduck.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 public class SpringSecurityConfig {
 
   @Bean
@@ -19,19 +24,16 @@ public class SpringSecurityConfig {
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http
         .csrf(AbstractHttpConfigurer::disable)
+        .cors(Customizer.withDefaults())
+        .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers(
-                "/api/v1/members/**",
-                "/api/v1/problems/**",
-                "/api/v1/submissions/**",
-                "/swagger-ui/**",
-                "/api-docs/**",
-                "/actuator/health"
-            ).permitAll()
-            .anyRequest().authenticated()
+            .requestMatchers(HttpMethod.PUT, "/api/v1/members").authenticated()
+            .requestMatchers(HttpMethod.POST, "/api/v1/submissions").authenticated()
+            .anyRequest().permitAll()
         )
         .formLogin(AbstractHttpConfigurer::disable) // 기본 로그인 폼 제거
         .httpBasic(AbstractHttpConfigurer::disable); // HTTP Basic 인증 제거
+
 
     return http.build();
   }

--- a/src/main/java/com/koreii/algoduck/config/WebConfig.java
+++ b/src/main/java/com/koreii/algoduck/config/WebConfig.java
@@ -1,12 +1,10 @@
 package com.koreii.algoduck.config;
 
-import com.koreii.algoduck.interceptor.SessionLoginInterceptor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -18,17 +16,10 @@ public class WebConfig implements WebMvcConfigurer {
 
   @Override
   public void addCorsMappings(CorsRegistry registry) {
-    registry.addMapping("/api/v1/**") // API 경로
-        .allowedOrigins("http://localhost:3000", clientDomainName) // 허용할 클라이언트 주소
-        .allowedMethods("GET", "POST", "PUT", "DELETE") // 허용할 HTTP 메서드
+    registry.addMapping("/**") // API 경로
+        .allowedOriginPatterns("http://localhost:3000", clientDomainName) // 허용할 클라이언트 주소
+        .allowedMethods("GET", "POST", "PUT", "DELETE, OPTIONS") // 허용할 HTTP 메서드
         .allowedHeaders("*") // 허용할 헤더
-        .allowCredentials(true); // 인증 정보 포함 여부
-  }
-
-  @Override
-  public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(loginInterceptor)
-        .addPathPatterns("/**") // 일단 모든 요청에 대해 로그인 검사
-        .excludePathPatterns("/**"); // 비로그인 허용하는 일부 URL 제외
+        .allowCredentials(true); // 인증 정보 포함 여부, 세션 쿠키 허용
   }
 }

--- a/src/main/java/com/koreii/algoduck/interceptor/SessionLoginInterceptor.java
+++ b/src/main/java/com/koreii/algoduck/interceptor/SessionLoginInterceptor.java
@@ -16,6 +16,7 @@ public class SessionLoginInterceptor implements HandlerInterceptor {
   @Override
   public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
     HttpSession session = request.getSession(false);
+    log.info("preHandle {}", session);
 
     if (session == null || session.getAttribute(LOGIN_MEMBER) == null) {
       log.info("로그인되지 않은 사용자 요청 차단. 요청 URI: {}", request.getRequestURI());

--- a/src/main/java/com/koreii/algoduck/member/controller/MemberController.java
+++ b/src/main/java/com/koreii/algoduck/member/controller/MemberController.java
@@ -8,7 +8,9 @@ import com.koreii.algoduck.member.dto.request.MemberUpdateRequestDto;
 import com.koreii.algoduck.member.dto.response.MemberPagingResponseDto;
 import com.koreii.algoduck.member.dto.response.MemberResponseDto;
 import com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto;
+import com.koreii.algoduck.member.entity.Member;
 import com.koreii.algoduck.member.enums.Role;
+import com.koreii.algoduck.member.security.CustomUserDetails;
 import com.koreii.algoduck.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,6 +21,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -152,11 +159,17 @@ public class MemberController extends BaseApiController {
   }
 
   @Operation(summary = "회원 정보 업데이트", description = "회원 정보를 업데이트합니다.")
-  @PutMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<ApiResponse<MemberResponseDto>> update(
-      @PathVariable Long memberId,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestPart("memberUpdateRequestDto") MemberUpdateRequestDto memberUpdateRequestDto,
       @RequestPart(value = "file", required = false) MultipartFile file) {
+    if (userDetails == null) {
+      log.warn("인증된 사용자 없음");
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("로그인이 필요합니다."));
+    }
+
+    Long memberId = userDetails.getMemberId();
     log.info("memberUpdateRequestDto = {}", memberUpdateRequestDto);
     log.info("file = {}", file);
 
@@ -169,11 +182,21 @@ public class MemberController extends BaseApiController {
   public ResponseEntity<ApiResponse<MemberResponseDto>> login(
       @RequestBody LoginRequestDto loginRequestDto,
       HttpServletRequest request) {
-    MemberResponseDto memberResponseDto = memberService.login(
+    Member member = memberService.login(
         loginRequestDto.getLoginId(),
         loginRequestDto.getPassword(),
         request
     );
+
+    MemberResponseDto memberResponseDto = new MemberResponseDto(member);
+    CustomUserDetails userDetails = new CustomUserDetails(member);
+
+    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+    context.setAuthentication(authToken);
+
+    HttpSession session = request.getSession(true);
+    session.setAttribute(HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, context);
 
     return ResponseEntity.ok(ApiResponse.success(memberResponseDto));
   }

--- a/src/main/java/com/koreii/algoduck/member/security/CustomUserDetails.java
+++ b/src/main/java/com/koreii/algoduck/member/security/CustomUserDetails.java
@@ -1,0 +1,55 @@
+package com.koreii.algoduck.member.security;
+
+import com.koreii.algoduck.member.entity.Member;
+import com.koreii.algoduck.member.enums.MemberStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+  private final Member member;
+
+  public Long getMemberId() {
+    return member.getMemberId();
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + member.getRole().name()));
+  }
+
+  @Override
+  public String getPassword() {
+    return member.getPassword();
+  }
+
+  @Override
+  public String getUsername() {
+    return member.getLoginId();
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true; // 계정 만료 안 함
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true; // 잠금 없음
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true; // 비밀번호 유효
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return member.getMemberStatus() == MemberStatus.ACTIVE; // 탈퇴 요청 여부 등 고려
+  }
+}

--- a/src/main/java/com/koreii/algoduck/member/security/CustomerUserDetailService.java
+++ b/src/main/java/com/koreii/algoduck/member/security/CustomerUserDetailService.java
@@ -1,0 +1,22 @@
+package com.koreii.algoduck.member.security;
+
+import com.koreii.algoduck.member.entity.Member;
+import com.koreii.algoduck.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerUserDetailService implements UserDetailsService {
+  private final MemberRepository memberRepository;
+
+  @Override
+  public UserDetails loadUserByUsername(String loginId) throws UsernameNotFoundException {
+    Member member = memberRepository.findByLoginId(loginId).orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+    return new CustomUserDetails(member);
+  }
+}

--- a/src/main/java/com/koreii/algoduck/member/service/LoginService.java
+++ b/src/main/java/com/koreii/algoduck/member/service/LoginService.java
@@ -8,7 +8,7 @@ import jakarta.servlet.http.HttpSession;
 import static com.koreii.algoduck.util.constants.Constants.LOGIN_MEMBER;
 
 public interface LoginService {
-  MemberResponseDto login(String loginId, String password, HttpServletRequest request);
+  Member login(String loginId, String password, HttpServletRequest request);
 
   void logout(HttpServletRequest request);
 

--- a/src/main/java/com/koreii/algoduck/member/service/MemberService.java
+++ b/src/main/java/com/koreii/algoduck/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.member.dto.request.MemberSaveRequestDto;
 import com.koreii.algoduck.member.dto.request.MemberUpdateRequestDto;
 import com.koreii.algoduck.member.dto.response.MemberResponseDto;
 import com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto;
+import com.koreii.algoduck.member.entity.Member;
 import com.koreii.algoduck.member.enums.Role;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -42,7 +43,7 @@ public interface MemberService {
 
   MemberResponseDto update(Long memberId, MemberUpdateRequestDto memberUpdateRequestDto, MultipartFile file);
 
-  MemberResponseDto login(String loginId, String password, HttpServletRequest request);
+  Member login(String loginId, String password, HttpServletRequest request);
 
   void logout(HttpServletRequest request);
 

--- a/src/main/java/com/koreii/algoduck/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/member/service/MemberServiceImpl.java
@@ -7,6 +7,7 @@ import com.koreii.algoduck.member.dto.request.MemberSaveRequestDto;
 import com.koreii.algoduck.member.dto.request.MemberUpdateRequestDto;
 import com.koreii.algoduck.member.dto.response.MemberResponseDto;
 import com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto;
+import com.koreii.algoduck.member.entity.Member;
 import com.koreii.algoduck.member.enums.Role;
 import com.koreii.algoduck.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -193,7 +194,7 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  public MemberResponseDto login(String loginId, String password, HttpServletRequest request) {
+  public Member login(String loginId, String password, HttpServletRequest request) {
     return loginService.login(loginId, password, request);
   }
 

--- a/src/main/java/com/koreii/algoduck/member/service/SessionLoginServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/member/service/SessionLoginServiceImpl.java
@@ -20,7 +20,7 @@ public class SessionLoginServiceImpl implements LoginService {
   private final MemberRepository memberRepository;
   private final BCryptPasswordEncoder passwordEncoder;
 
-  public MemberResponseDto login(String loginId, String password, HttpServletRequest request) {
+  public Member login(String loginId, String password, HttpServletRequest request) {
     Member member = memberRepository.findByLoginId(loginId)
         .orElseThrow(() -> new LoginFailureException("아이디 또는 비밀번호가 올바르지 않습니다."));
 
@@ -34,7 +34,7 @@ public class SessionLoginServiceImpl implements LoginService {
     //  세션에 로그인 회원 정보 저장
     session.setAttribute(LOGIN_MEMBER, member);
 
-    return new MemberResponseDto(member);
+    return member;
   }
 
   public void logout(HttpServletRequest request) {

--- a/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
+++ b/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
@@ -3,6 +3,7 @@ package com.koreii.algoduck.submission.controller;
 import com.koreii.algoduck.base.controller.BaseApiController;
 import com.koreii.algoduck.base.dto.page.PageResponse;
 import com.koreii.algoduck.base.dto.response.ApiResponse;
+import com.koreii.algoduck.member.security.CustomUserDetails;
 import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import com.koreii.algoduck.submission.service.SubmissionService;
@@ -12,14 +13,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,7 +31,11 @@ public class SubmissionController extends BaseApiController {
 
   @Operation(summary = "제출", description = "문제에 대한 코드를 제출합니다.")
   @PostMapping
-  public ResponseEntity<ApiResponse<SubmissionResponseDto>> submit(@RequestBody SubmissionRequestDto submissionRequestDto) {
+  public ResponseEntity<ApiResponse<SubmissionResponseDto>> submit(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody SubmissionRequestDto submissionRequestDto) {
+    if (userDetails == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.failure("로그인이 필요합니다."));
+    }
+
     SubmissionResponseDto submissionResponseDto = submissionService.submit(submissionRequestDto);
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(submissionResponseDto));
   }


### PR DESCRIPTION
- Spring Security의 SecurityContext를 세션에 저장하도록 로그인 로직 수정
- PUT /members, POST /submissions 요청을 인증 필요로 설정
- WebMvcConfigurer에 CORS 설정 강화 (allowedOriginPatterns, OPTIONS 허용)
- Interceptor 제거 및 Spring Security 인증 흐름으로 전환
- @AuthenticationPrincipal 기반 인증자 주입 방식 적용
- CustomUserDetails, MemberSecurityDto, CustomUserDetailService 구성 및 적용