### PR TITLE
[bugfix] 로그인 실패 시 상태 코드를 400 → 401로 수정

### DIFF
--- a/src/main/java/com/koreii/algoduck/base/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/koreii/algoduck/base/handler/GlobalExceptionHandler.java
@@ -59,7 +59,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(LoginFailureException.class)
   public ResponseEntity<ApiResponse<Void>> handleLoginFailureException(LoginFailureException e) {
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+    return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
         .body(ApiResponse.failure(e.getMessage()));
   }
 


### PR DESCRIPTION
- 로그인 실패(없는 아이디 또는 비밀번호 틀림)에 대해 HTTP 상태 코드를 기존 400(Bad Request)에서 401(Unauthorized)로 변경하여 프론트엔드에서 인증 실패와 세션 만료를 구분할 수 있도록 함.