### PR TITLE
[feat] 제출 코드 문자열로 조회하는 기능 추가

### DIFF
--- a/src/main/java/com/koreii/algoduck/exceptions/file/FileDownloadFailException.java
+++ b/src/main/java/com/koreii/algoduck/exceptions/file/FileDownloadFailException.java
@@ -1,0 +1,18 @@
+package com.koreii.algoduck.exceptions.file;
+
+public class FileDownloadFailException extends RuntimeException {
+  public FileDownloadFailException() {
+  }
+
+  public FileDownloadFailException(String message) {
+    super(message);
+  }
+
+  public FileDownloadFailException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public FileDownloadFailException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/com/koreii/algoduck/exceptions/file/s3/AmazonS3FileDownloadFailException.java
+++ b/src/main/java/com/koreii/algoduck/exceptions/file/s3/AmazonS3FileDownloadFailException.java
@@ -1,0 +1,20 @@
+package com.koreii.algoduck.exceptions.file.s3;
+
+import com.koreii.algoduck.exceptions.file.FileDownloadFailException;
+
+public class AmazonS3FileDownloadFailException extends FileDownloadFailException {
+  public AmazonS3FileDownloadFailException() {
+  }
+
+  public AmazonS3FileDownloadFailException(String message) {
+    super(message);
+  }
+
+  public AmazonS3FileDownloadFailException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public AmazonS3FileDownloadFailException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/com/koreii/algoduck/file/FileStorageService.java
+++ b/src/main/java/com/koreii/algoduck/file/FileStorageService.java
@@ -8,4 +8,6 @@ public interface FileStorageService {
   CompletableFuture<String> uploadFile(String repositoryName, String folderPath, MultipartFile file);
 
   CompletableFuture<Void> deleteFile(String repositoryName, String fileUrl);
+
+  CompletableFuture<byte[]> downloadFile(String repositoryName, String fileUrl);
 }

--- a/src/main/java/com/koreii/algoduck/file/FileStorageServiceAmazonS3Impl.java
+++ b/src/main/java/com/koreii/algoduck/file/FileStorageServiceAmazonS3Impl.java
@@ -2,9 +2,13 @@ package com.koreii.algoduck.file;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.util.IOUtils;
 import com.koreii.algoduck.exceptions.file.FileUploadFailException;
+import com.koreii.algoduck.exceptions.file.s3.AmazonS3FileDownloadFailException;
 import com.koreii.algoduck.exceptions.file.s3.AmazonS3FileUploadFailException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -56,6 +60,21 @@ public class FileStorageServiceAmazonS3Impl implements FileStorageService {
     }
 
     return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  @Async("fileExecutor")
+  public CompletableFuture<byte[]> downloadFile(String repositoryName, String fileUrl) {
+    try {
+      String key = getKey(repositoryName, fileUrl);
+      S3Object s3Object = amazonS3.getObject(new GetObjectRequest(repositoryName, key));
+
+      byte[] bytes = IOUtils.toByteArray(s3Object.getObjectContent()); // Apache Commons IO 필요
+      return CompletableFuture.completedFuture(bytes);
+    } catch (Exception e) {
+      log.error("Failed to download file from S3: {}", fileUrl, e);
+      throw new AmazonS3FileDownloadFailException("파일 다운로드에 실패했습니다.", e);
+    }
   }
 
   private String uploadS3File(String bucketName, String filePath, MultipartFile file) {

--- a/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
+++ b/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -58,5 +59,13 @@ public class SubmissionController extends BaseApiController {
     }
 
     return ResponseEntity.ok(ApiResponse.success(page));
+  }
+
+  @GetMapping("/{submissionId}/code")
+  public ResponseEntity<ApiResponse<String>> getCode(
+      @PathVariable Long submissionId
+  ) {
+    String code = submissionService.getCode(submissionId);
+    return ResponseEntity.ok(ApiResponse.success(code));
   }
 }

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
@@ -23,4 +23,6 @@ public interface SubmissionService {
 
   // 이전 페이지 요청 (현재 첫 ID 기준으로 더 최신 데이터 조회)
   PageResponse<SubmissionResponseDto> getPrevPage(Long firstSeenId, int pageSize);
+
+  String getCode(Long submissionId);
 }

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
@@ -11,6 +11,7 @@ import com.koreii.algoduck.submission.dto.request.SubmissionSaveRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionUpdateRequestDto;
 import com.koreii.algoduck.submission.dto.response.JudgeResponseDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
+import com.koreii.algoduck.submission.entity.Submission;
 import com.koreii.algoduck.submission.repository.SubmissionRepository;
 import com.koreii.algoduck.version.dto.response.VersionResponseDto;
 import com.koreii.algoduck.version.service.VersionService;
@@ -166,6 +167,16 @@ public class SubmissionServiceImpl implements SubmissionService {
   @Override
   public PageResponse<SubmissionResponseDto> getPrevPage(Long firstSeenId, int pageSize) {
     return submissionRepository.findPrevPage(firstSeenId, pageSize);
+  }
+
+  @Override
+  public String getCode(Long submissionId) {
+    Submission submission = submissionRepository.findBySubmissionId(submissionId);
+    byte[] codeBytes = fileStorageService
+        .downloadFile(bucketName, submission.getCodeUrl())
+        .join(); // ← CompletableFuture<byte[]> → byte[] (동기화)
+
+    return new String(codeBytes, StandardCharsets.UTF_8);
   }
 
 }


### PR DESCRIPTION
- FileStorageService에 일반 파일 다운로드 메서드 추가
- S3에서 byte[] 형태로 파일을 비동기 다운로드하는 로직 구현
- 제출 ID로 코드 문자열을 조회하는 SubmissionService 및 Controller 기능 추가
- 컨트롤러에서 /submissions/{submissionId}/code 경로로 코드 응답 제공