### PR TITLE
[bugfix] 크로스 도메인 세션 유지를 위한 SameSite 및 Secure 쿠키 설정 추가

### DIFF
--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -71,3 +71,6 @@ server:
   servlet:
     session:
       timeout: 30m
+      cookie:
+        same-site: None
+        secure: true


### PR DESCRIPTION
- same-site: None, secure: true 설정을 통해 HTTPS 기반 cross-origin 쿠키 전송 허용
- vercel 프론트와 duckdns 백엔드 간 세션 인증 유지 문제 해결