### PR TITLE
[feat] 브라우저 자동 정적 요청 무시용 StaticResourceBlockController 추가

### DIFF
--- a/src/main/java/com/koreii/algoduck/assets/controller/StaticResourceBlockController.java
+++ b/src/main/java/com/koreii/algoduck/assets/controller/StaticResourceBlockController.java
@@ -1,0 +1,24 @@
+package com.koreii.algoduck.assets.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StaticResourceBlockController {
+
+  @GetMapping({
+      "/favicon.ico",
+      "/robots.txt",
+      "/apple-touch-icon.png",
+      "/apple-touch-icon-precomposed.png",
+      "/site.webmanifest",
+      "/browserconfig.xml",
+      "/manifest.json",
+      "/logo192.png",
+      "/logo512.png"
+  })
+  public void blockStaticRequests(HttpServletResponse response) {
+    response.setStatus(HttpServletResponse.SC_NO_CONTENT); // 204 No Content
+  }
+}


### PR DESCRIPTION
- /favicon.ico, /robots.txt, /manifest.json 등 불필요한 요청을 무시하도록 처리
- 204 No Content 응답으로 예외 로그 방지 및 불필요한 처리 최소화
- API 서버 로그 정리 및 안정성 향상 목적