### PR TITLE
[feat] 채점 진행 상황을 SSE로 클라이언트에 실시간 전송하는 기능 구현

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
+++ b/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
@@ -5,8 +5,10 @@ import com.koreii.algoduck.base.dto.page.PageResponse;
 import com.koreii.algoduck.base.dto.response.ApiResponse;
 import com.koreii.algoduck.member.security.CustomUserDetails;
 import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
+import com.koreii.algoduck.submission.dto.response.JudgeProgressDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import com.koreii.algoduck.submission.service.SubmissionService;
+import com.koreii.algoduck.submission.sse.SubmissionProgressEmitter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class SubmissionController extends BaseApiController {
   private final SubmissionService submissionService;
+  private final SubmissionProgressEmitter submissionProgressEmitter;
 
   @Operation(summary = "제출", description = "문제에 대한 코드를 제출합니다.")
   @PostMapping
@@ -67,5 +75,10 @@ public class SubmissionController extends BaseApiController {
   ) {
     String code = submissionService.getCode(submissionId);
     return ResponseEntity.ok(ApiResponse.success(code));
+  }
+
+  @GetMapping("/{submissionId}/progress")
+  public SseEmitter subscribe(@PathVariable Long submissionId) {
+    return submissionProgressEmitter.createEmitter(submissionId);
   }
 }

--- a/src/main/java/com/koreii/algoduck/submission/dto/request/JudgeRequestDto.java
+++ b/src/main/java/com/koreii/algoduck/submission/dto/request/JudgeRequestDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 public class JudgeRequestDto {
   private Long problemId;
+  private Long submissionId;
   private String language;
   private String version;
   private int timeLimitation;

--- a/src/main/java/com/koreii/algoduck/submission/dto/response/JudgeProgressDto.java
+++ b/src/main/java/com/koreii/algoduck/submission/dto/response/JudgeProgressDto.java
@@ -14,6 +14,7 @@ import lombok.ToString;
 @ToString
 public class JudgeProgressDto {
   private int index;
+  private Long submissionId;
   private String result;
   private String message;
   private String stdout;

--- a/src/main/java/com/koreii/algoduck/submission/service/JudgeServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/JudgeServiceImpl.java
@@ -3,6 +3,7 @@ package com.koreii.algoduck.submission.service;
 import com.koreii.algoduck.submission.dto.request.JudgeRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.response.JudgeResponseDto;
+import com.koreii.algoduck.submission.sse.SubmissionProgressEmitter;
 import com.koreii.algoduck.submission.websocket.JudgeWebSocketClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +25,7 @@ public class  JudgeServiceImpl implements JudgeService {
   private String wsJudgeUrl;
   @Value("${judge.server.https-judge}")
   private String httpsJudgeUrl;
+  private final SubmissionProgressEmitter submissionProgressEmitter;
 
   @Async("judgeExecutor")
   @Override
@@ -34,7 +36,7 @@ public class  JudgeServiceImpl implements JudgeService {
       URI uri = new URI(wsJudgeUrl);
 
       log.info("uri = {}", uri);
-      JudgeWebSocketClient judgeWebSocketClient = new JudgeWebSocketClient(uri, judgeRequestDto, future);
+      JudgeWebSocketClient judgeWebSocketClient = new JudgeWebSocketClient(uri, judgeRequestDto, submissionProgressEmitter, future);
       judgeWebSocketClient.connect();
     } catch (URISyntaxException e) {
       log.error("잘못된 Judge 서버 URI");

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
@@ -114,6 +114,7 @@ public class SubmissionServiceImpl implements SubmissionService {
 
     JudgeRequestDto judgeRequestDto = JudgeRequestDto.builder()
         .problemId(submissionRequestDto.getProblemId())
+        .submissionId(submissionId)
         .language(versionResponseDto.getLanguageName())
         .version(versionResponseDto.getVersionName())
         .timeLimitation(problemResponseDto.getTimeLimitation())

--- a/src/main/java/com/koreii/algoduck/submission/sse/SubmissionProgressEmitter.java
+++ b/src/main/java/com/koreii/algoduck/submission/sse/SubmissionProgressEmitter.java
@@ -1,0 +1,38 @@
+package com.koreii.algoduck.submission.sse;
+
+import com.koreii.algoduck.submission.dto.response.JudgeProgressDto;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class SubmissionProgressEmitter {
+
+  private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+  public SseEmitter createEmitter(Long submissionId) {
+    SseEmitter emitter = new SseEmitter(60 * 1000L);
+    emitters.put(submissionId, emitter);
+
+    emitter.onTimeout(() -> emitters.remove(submissionId));
+    emitter.onCompletion(() -> emitters.remove(submissionId));
+
+    return emitter;
+  }
+
+  public void sendProgress(Long submissionId, JudgeProgressDto progressDto) {
+    SseEmitter emitter = emitters.get(submissionId);
+    if (emitter != null) {
+      try {
+        emitter.send(SseEmitter.event()
+            .name("progress")
+            .data(progressDto));
+      } catch (IOException e) {
+        emitter.completeWithError(e);
+      }
+    }
+  }
+}

--- a/src/main/java/com/koreii/algoduck/submission/websocket/JudgeWebSocketClient.java
+++ b/src/main/java/com/koreii/algoduck/submission/websocket/JudgeWebSocketClient.java
@@ -2,9 +2,11 @@ package com.koreii.algoduck.submission.websocket;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.koreii.algoduck.submission.controller.SubmissionController;
 import com.koreii.algoduck.submission.dto.request.JudgeRequestDto;
 import com.koreii.algoduck.submission.dto.response.JudgeProgressDto;
 import com.koreii.algoduck.submission.dto.response.JudgeResponseDto;
+import com.koreii.algoduck.submission.sse.SubmissionProgressEmitter;
 import lombok.extern.slf4j.Slf4j;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
@@ -16,12 +18,15 @@ import java.util.concurrent.CompletableFuture;
 public class JudgeWebSocketClient extends WebSocketClient {
   private static final ObjectMapper objectMapper = new ObjectMapper();
   private final JudgeRequestDto judgeRequestDto;
+  private final SubmissionProgressEmitter submissionProgressEmitter;
   private final CompletableFuture<JudgeResponseDto> future;
 
-  public JudgeWebSocketClient(URI serverUri, JudgeRequestDto judgeRequestDto, CompletableFuture<JudgeResponseDto> future) {
+  public JudgeWebSocketClient(URI serverUri, JudgeRequestDto judgeRequestDto, SubmissionProgressEmitter submissionProgressEmitter, CompletableFuture<JudgeResponseDto> future) {
     super(serverUri);
     this.judgeRequestDto = judgeRequestDto;
+    this.submissionProgressEmitter = submissionProgressEmitter;
     this.future = future;
+
   }
 
   @Override
@@ -36,17 +41,20 @@ public class JudgeWebSocketClient extends WebSocketClient {
   @Override
   public void onMessage(String message) {
     try {
-      JudgeProgressDto progress = objectMapper.readValue(message, JudgeProgressDto.class);
-      log.info("채점 진행중: {}%", progress.getPercentage());
+      JudgeProgressDto progressDto = objectMapper.readValue(message, JudgeProgressDto.class);
+      log.info("채점 진행중: {}%", progressDto.getPercentage());
+
+      //  실시간 진행률을 클라이언트에 전송 (SSE)
+      submissionProgressEmitter.sendProgress(judgeRequestDto.getSubmissionId(), progressDto);
 
       //  최종 성공
-      if ("AC".equals(progress.getResult())) {
+      if ("AC".equals(progressDto.getResult())) {
         log.info("Accepted");
-        future.complete(new JudgeResponseDto(progress));
+        future.complete(new JudgeResponseDto(progressDto));
         close();
-      }  else if (!"PASS".equals(progress.getResult())) {  //  중단 조건 도달 (e.g. WA, TLE, RE...)
-        log.warn("중단 - {}", progress.getResult());
-        future.complete(new JudgeResponseDto(progress));
+      }  else if (!"PASS".equals(progressDto.getResult())) {  //  중단 조건 도달 (e.g. WA, TLE, RE...)
+        log.warn("중단 - {}", progressDto.getResult());
+        future.complete(new JudgeResponseDto(progressDto));
         close();
       }
     } catch (JsonProcessingException e) {


### PR DESCRIPTION
- 채점 결과를 전송하는 JudgeProgressDto에 submissionId 필드를 추가하여 각 제출 건을 식별 가능하도록 개선
- SubmissionController에 /{submissionId}/progress 엔드포인트 추가 → 클라이언트가 SSE(SseEmitter)를 통해 특정 제출에 대한 채점 진행률을 구독할 수 있도록 구현
- SubmissionProgressEmitter 컴포넌트 생성 → submissionId 기준으로 emitter를 생성/보관하고, JudgeWebSocketClient에서 채점 결과를 수신할 때 해당 emitter를 통해 프론트엔드에 실시간 전송
- JudgeRequestDto에 submissionId 필드 추가 및 생성 시 전달되도록 SubmissionServiceImpl 수정
- JudgeWebSocketClient가 채점 결과(JudgeProgressDto)를 수신하면, emitter를 통해 클라이언트에 전송 후 종료 조건에 따라 future를 완료시키도록 로직 변경

기존 단방향 채점 구조에 실시간 채점 현황 제공 기능을 추가하여 사용자 경험 향상 도모