### PR TITLE
[feat] SSE 연결 정상 종료 처리 및 타임아웃 방지 로직 추가

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/sse/SubmissionProgressEmitter.java
+++ b/src/main/java/com/koreii/algoduck/submission/sse/SubmissionProgressEmitter.java
@@ -1,6 +1,7 @@
 package com.koreii.algoduck.submission.sse;
 
 import com.koreii.algoduck.submission.dto.response.JudgeProgressDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -9,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@Slf4j
 public class SubmissionProgressEmitter {
 
   private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
@@ -17,7 +19,12 @@ public class SubmissionProgressEmitter {
     SseEmitter emitter = new SseEmitter(60 * 1000L);
     emitters.put(submissionId, emitter);
 
-    emitter.onTimeout(() -> emitters.remove(submissionId));
+    emitter.onTimeout(() -> {
+      log.warn("SSE 타임아웃 발생: submissionId = {}", submissionId);
+      emitter.complete();
+      emitters.remove(submissionId);
+
+    });
     emitter.onCompletion(() -> emitters.remove(submissionId));
 
     return emitter;
@@ -30,6 +37,11 @@ public class SubmissionProgressEmitter {
         emitter.send(SseEmitter.event()
             .name("progress")
             .data(progressDto));
+
+        if (!"PASS".equals(progressDto.getResult())) {
+          emitter.complete();
+          emitters.remove(submissionId);
+        }
       } catch (IOException e) {
         emitter.completeWithError(e);
       }

--- a/src/main/java/com/koreii/algoduck/submission/websocket/JudgeWebSocketClient.java
+++ b/src/main/java/com/koreii/algoduck/submission/websocket/JudgeWebSocketClient.java
@@ -60,7 +60,6 @@ public class JudgeWebSocketClient extends WebSocketClient {
     } catch (JsonProcessingException e) {
       onError(e);
     }
-    // 결과를 DB에 저장하거나 SSE로 React에 push
   }
 
   @Override


### PR DESCRIPTION
- 채점 종료 시 (AC, WA, TLE 등) SseEmitter.complete() 호출하여 연결 명시적 종료
- 타임아웃 발생 시 로그 기록 및 emitter 제거 처리 추가
- JudgeWebSocketClient 내 onMessage 주석 정리
- 불필요한 연결 유지로 인해 발생하던 AsyncRequestTimeoutException 방지