### PR TITLE
[bugfix] deploy.yml의 파일 복사 목록에서 누락된 쉼표 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,7 @@ jobs:
             build/libs/*.jar,
             Dockerfile,
             docker-compose.yml,
-            .env
+            .env,
             src/main/resources/application.yml
           target: "~/algoduck"
 


### PR DESCRIPTION
- .env와 application.yml 사이에 쉼표(,) 누락으로 인해 파일 복사가 실패하던 문제 수정
- application.yml이 정상적으로 EC2에 복사되도록 수정