### PR TITLE
[chore] 민감 정보 파일 EC2에 남기지 않도록 배포 스크립트 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,10 @@ jobs:
           script: |
             cd ~/algoduck
 
+            echo "🔐 파일 권한 설정"
+            chmod 600 .env || echo ".env 없음"
+            chmod 600 src/main/resources/application.yml || echo "application.yml 없음"
+
             echo "📦 컨테이너 로그 백업 (docker logs 형식)"
             CONTAINER_NAME=algoduck
             TIMESTAMP=$(date +%Y%m%d_%H%M%S)
@@ -107,8 +111,8 @@ jobs:
             echo "🚀 Spring 앱 컨테이너 빌드 및 실행"
             docker-compose up -d --build app
 
-            echo "🔒 .env 파일 권한 설정"
-            chmod 600 .env
+            echo "🧼 빌드 후 민감한 설정 파일 삭제"
+            rm -f .env src/main/resources/application.yml
 
       - name: Health Check
         run: |


### PR DESCRIPTION
- application.yml과 .env 파일은 도커 이미지에만 포함되도록 변경
- docker-compose 빌드 후 EC2 파일시스템에서 해당 파일 삭제
- application.yml 권한을 600으로 제한하여 보안 강화