### PR TITLE
[chore] WAS Dockerfile에 vi 및 유틸리티 도구 설치 및 bash 프롬프트 개선

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,28 @@
-# 베이스 이미지로 Java 17 사용
-FROM openjdk:17
+# Java + 유틸리티 포함된 slim 베이스 이미지
+FROM openjdk:17-slim
 
-# JAR 파일 이름을 빌드 시 인자로 전달받기
-ARG JAR_FILE=build/libs/algoduck-0.0.1-SNAPSHOT.jar
-
-# JAR 파일을 이미지에 복사
-COPY ${JAR_FILE} app.jar
-
-COPY src/main/resources/application.yml /app/application.yml
-COPY .env /app/.env
+# 필요한 유틸리티 설치: bash, vi, clear, ps, etc.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    bash \
+    procps \
+    curl \
+    less \
+    vim-tiny \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # 작업 디렉토리 설정
 WORKDIR /app
+
+# JAR 파일 이름을 빌드 시 인자로 전달받기
+ARG JAR_FILE=build/libs/algoduck-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+
+# 설정 파일 복사
+COPY src/main/resources/application.yml /app/application.yml
+COPY .env /app/.env
+
+# 보기 좋은 PS1 설정
+RUN echo "PS1='[\\u@\\h \\w]# '" >> /root/.bashrc
 
 # 애플리케이션 실행
 ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
- slim 기반 Java 이미지에 bash, vi, curl, less, procps 등 최소 유틸 설치
- clear, ps, vi 등 도커 exec 환경에서 편리한 도구 사용 가능하도록 설정
- /root/.bashrc에 PS1 설정 추가하여 접속 시 프롬프트 가독성 향상