### PR TITLE
[bugfix] ENTRYPOINT의 jar 경로 오류 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY .env /app/.env
 RUN echo "PS1='[\\u@\\h \\w]# '" >> /root/.bashrc
 
 # 애플리케이션 실행
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
- COPY로 JAR 파일을 /app 디렉토리에 복사했으나 ENTRYPOINT에서 /app.jar로 잘못 지정되어 실행 실패
- ENTRYPOINT 경로를 "app.jar"로 수정하여 WORKDIR(/app) 기준에 맞게 실행되도록 변경