### PR TITLE
[feat] judge-result 큐 수신을 위한 Consumer 및 메시지 정의

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/mq/consumer/JudgeResultConsumer.java
+++ b/src/main/java/com/koreii/algoduck/submission/mq/consumer/JudgeResultConsumer.java
@@ -1,0 +1,31 @@
+package com.koreii.algoduck.submission.mq.consumer;
+
+import com.koreii.algoduck.submission.dto.request.SubmissionUpdateRequestDto;
+import com.koreii.algoduck.submission.mq.message.result.JudgeResultMessage;
+import com.koreii.algoduck.submission.service.SubmissionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class JudgeResultConsumer {
+  private final SubmissionService submissionService;
+
+  @RabbitListener(queues = "${rabbitmq.queue.result}")
+  public void receiveJudgeResult(JudgeResultMessage resultMessage) {
+    log.info("채점 결과 수신: {}", resultMessage);
+
+    SubmissionUpdateRequestDto updateDto = SubmissionUpdateRequestDto.builder()
+        .submissionId(resultMessage.getSubmissionId())
+        .status(resultMessage.getResult())
+        .message(resultMessage.getMessage())
+        .executionTime(resultMessage.getExecutionTime())
+        .memoryUsage(resultMessage.getMemoryUsage())
+        .build();
+
+    submissionService.updateSubmission(updateDto);
+  }
+}

--- a/src/main/java/com/koreii/algoduck/submission/mq/message/request/JudgeRequestMessage.java
+++ b/src/main/java/com/koreii/algoduck/submission/mq/message/request/JudgeRequestMessage.java
@@ -1,11 +1,10 @@
-package com.koreii.algoduck.submission.message.request;
+package com.koreii.algoduck.submission.mq.message.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 
 @Getter
 @Setter

--- a/src/main/java/com/koreii/algoduck/submission/mq/message/result/JudgeResultMessage.java
+++ b/src/main/java/com/koreii/algoduck/submission/mq/message/result/JudgeResultMessage.java
@@ -1,0 +1,20 @@
+package com.koreii.algoduck.submission.mq.message.result;
+
+import com.koreii.algoduck.submission.enums.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class JudgeResultMessage {
+  private Long problemId;
+  private Long submissionId;
+  private Status result;
+  private String message;
+  private String stdout;
+  private String stderr;
+  private Integer executionTime;
+  private Integer memoryUsage;
+}

--- a/src/main/java/com/koreii/algoduck/submission/mq/producer/JudgeRequestProducer.java
+++ b/src/main/java/com/koreii/algoduck/submission/mq/producer/JudgeRequestProducer.java
@@ -1,6 +1,6 @@
-package com.koreii.algoduck.submission.producer;
+package com.koreii.algoduck.submission.mq.producer;
 
-import com.koreii.algoduck.submission.message.request.JudgeRequestMessage;
+import com.koreii.algoduck.submission.mq.message.request.JudgeRequestMessage;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
@@ -5,15 +5,13 @@ import com.koreii.algoduck.exceptions.file.submission.SubmissionFailureException
 import com.koreii.algoduck.file.FileStorageService;
 import com.koreii.algoduck.problem.dto.response.ProblemResponseDto;
 import com.koreii.algoduck.problem.service.ProblemService;
-import com.koreii.algoduck.submission.dto.request.JudgeRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionSaveRequestDto;
 import com.koreii.algoduck.submission.dto.request.SubmissionUpdateRequestDto;
-import com.koreii.algoduck.submission.dto.response.JudgeResponseDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import com.koreii.algoduck.submission.entity.Submission;
-import com.koreii.algoduck.submission.message.request.JudgeRequestMessage;
-import com.koreii.algoduck.submission.producer.JudgeRequestProducer;
+import com.koreii.algoduck.submission.mq.message.request.JudgeRequestMessage;
+import com.koreii.algoduck.submission.mq.producer.JudgeRequestProducer;
 import com.koreii.algoduck.submission.repository.SubmissionRepository;
 import com.koreii.algoduck.version.dto.response.VersionResponseDto;
 import com.koreii.algoduck.version.service.VersionService;


### PR DESCRIPTION
- JudgeResultMessage.java 정의: 채점 결과 메시지 구조 설계
- JudgeResultConsumer.java 구현: judge-result 큐로부터 메시지 수신 및 DB 업데이트 처리
- SubmissionServiceImpl 수정: judge 결과 업데이트 로직 분리/연계
- JudgeRequest 관련 클래스 리팩토링: 패키지를 mq/message/request, mq/producer로 분리