### PR TITLE
[test] contextLoads 테스트에서 RabbitMQ 연결 실패 회피를 위한 MockBean 설정 대체

### DIFF
--- a/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
+++ b/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
@@ -1,7 +1,11 @@
 package com.koreii.algoduck;
 
+import com.koreii.algoduck.config.TestMockConfig;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
@@ -17,7 +21,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
         "spring.cloud.aws.s3.testcase_bucket=dummy-bucket"
     }
 )
+@Import(TestMockConfig.class)
 class AlgoduckApplicationTests {
+
   @Container
   static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
       .withDatabaseName("testdb")
@@ -34,5 +40,5 @@ class AlgoduckApplicationTests {
   @Test
   void contextLoads() {
   }
-
 }
+

--- a/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
+++ b/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
@@ -1,0 +1,22 @@
+package com.koreii.algoduck.config;
+
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import static org.mockito.Mockito.mock;
+
+@TestConfiguration
+public class TestMockConfig {
+
+  @Bean
+  public RabbitTemplate rabbitTemplate() {
+    return mock(RabbitTemplate.class);
+  }
+
+  @Bean
+  public AmqpAdmin amqpAdmin() {
+    return mock(AmqpAdmin.class);
+  }
+}


### PR DESCRIPTION
- RabbitTemplate, AmqpAdmin을 직접 Mock으로 정의한 TestMockConfig 클래스 생성
- SpringBootTest에 @Import(TestMockConfig.class) 추가
- Spring Boot 3.2 이상에서 @MockBean이 deprecated된 점을 반영하여 대체 방식 적용
- CI 환경에서 MQ 연결 실패로 인한 contextLoads() 테스트 실패 해결 목적