### PR TITLE
[test] MQ 관련 Bean 충돌 방지를 위한 @ConditionalOnMissingBean 조건 추가

### DIFF
--- a/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
+++ b/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
@@ -2,20 +2,25 @@ package com.koreii.algoduck.config;
 
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
 
 import static org.mockito.Mockito.mock;
 
 @TestConfiguration
+@Profile("test")
 public class TestMockConfig {
 
   @Bean
+  @ConditionalOnMissingBean(RabbitTemplate.class)
   public RabbitTemplate rabbitTemplate() {
     return mock(RabbitTemplate.class);
   }
 
   @Bean
+  @ConditionalOnMissingBean(AmqpAdmin.class)
   public AmqpAdmin amqpAdmin() {
     return mock(AmqpAdmin.class);
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
- RabbitTemplate, AmqpAdmin mock 등록 시 기존 빈이 존재하지 않을 경우에만 생성되도록 조정
- 운영 환경의 MQ 설정과 충돌 방지
- 테스트용 Mock Bean 안전하게 주입