### PR TITLE
[test] RabbitMQ 자동 설정 제외 및 MQ Bean Mock 처리로 contextLoads 테스트 안정화

### DIFF
--- a/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
+++ b/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
@@ -2,8 +2,10 @@ package com.koreii.algoduck;
 
 import com.koreii.algoduck.config.TestMockConfig;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -11,6 +13,8 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static junit.framework.TestCase.assertTrue;
 
 @Testcontainers
 @SpringBootTest(

--- a/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
+++ b/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
@@ -5,12 +5,10 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Profile;
 
 import static org.mockito.Mockito.mock;
 
 @TestConfiguration
-@Profile("test")
 public class TestMockConfig {
 
   @Bean

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,3 @@
 spring:
-  profiles:
-    active: test
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration


### PR DESCRIPTION
- test profile에서 RabbitAutoConfiguration을 exclude하여 MQ 연결 시도 차단
- TestMockConfig에서 RabbitTemplate과 AmqpAdmin을 mock으로 등록
- Mockito.mockingDetails()를 통한 mock 확인 테스트 추가
- contextLoads 테스트 시 MQ 연결 실패로 인한 CI 실패 방지