### PR TITLE
[test] MQ 관련 Bean 중복 정의 충돌 방지를 위한 이름 지정 및 테스트 설정 추가

### DIFF
--- a/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
+++ b/src/test/java/com/koreii/algoduck/config/TestMockConfig.java
@@ -11,14 +11,12 @@ import static org.mockito.Mockito.mock;
 @TestConfiguration
 public class TestMockConfig {
 
-  @Bean
-  @ConditionalOnMissingBean(RabbitTemplate.class)
+  @Bean(name = "mockRabbitTemplate")
   public RabbitTemplate rabbitTemplate() {
     return mock(RabbitTemplate.class);
   }
 
-  @Bean
-  @ConditionalOnMissingBean(AmqpAdmin.class)
+  @Bean(name = "mockAmqpAdmin")
   public AmqpAdmin amqpAdmin() {
     return mock(AmqpAdmin.class);
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,5 @@
 spring:
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+  main:
+    allow-bean-definition-overriding: true


### PR DESCRIPTION
- TestMockConfig 내 RabbitTemplate, AmqpAdmin Bean에 명시적 이름 부여 (mockRabbitTemplate, mockAmqpAdmin)
- application-test.yml에 spring.main.allow-bean-definition-overriding=true 추가
- contextLoads() 테스트 실행 시 BeanDefinitionOverrideException 우회
- 운영 환경에는 영향 없이 테스트 컨텍스트 내 MQ 의존성 제거 및 안정화