### PR TITLE
[test] 테스트 프로파일 활성화를 위한 @ActiveProfiles("test") 추가

### DIFF
--- a/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
+++ b/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
@@ -8,6 +8,7 @@ import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
@@ -16,6 +17,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static junit.framework.TestCase.assertTrue;
 
+@ActiveProfiles("test")
 @Testcontainers
 @SpringBootTest(
     properties = {


### PR DESCRIPTION
- application-test.yml의 autoconfigure.exclude 및 오버라이드 설정이 반영되지 않아 contextLoads 실패
- 테스트 클래스에 @ActiveProfiles("test") 추가로 명시적 적용