### PR TITLE
[test] RabbitMQ Testcontainers 통합 테스트 환경 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:mysql'
+	testImplementation("org.testcontainers:rabbitmq:1.20.4")
 
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 

--- a/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
+++ b/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
@@ -2,22 +2,15 @@ package com.koreii.algoduck;
 
 import com.koreii.algoduck.config.TestMockConfig;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.springframework.amqp.core.AmqpAdmin;
-import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-import static junit.framework.TestCase.assertTrue;
-
-@ActiveProfiles("test")
 @Testcontainers
 @SpringBootTest(
     properties = {
@@ -36,15 +29,27 @@ class AlgoduckApplicationTests {
       .withUsername("testuser")
       .withPassword("testpass");
 
+  @Container
+  static RabbitMQContainer rabbitMQ = new RabbitMQContainer("rabbitmq:3.11-management")
+      .withExposedPorts(5672, 15672)
+      .withUser("testuser", "testpass")
+      .withVhost("/")
+      .withPermission("/", "testuser", ".*", ".*", ".*");
+
   @DynamicPropertySource
   static void configureProperties(DynamicPropertyRegistry registry) {
     registry.add("spring.datasource.url", mysql::getJdbcUrl);
     registry.add("spring.datasource.username", mysql::getUsername);
     registry.add("spring.datasource.password", mysql::getPassword);
+
+    registry.add("spring.rabbitmq.host", rabbitMQ::getHost);
+    registry.add("spring.rabbitmq.port", () -> rabbitMQ.getMappedPort(5672));
+    registry.add("spring.rabbitmq.username", () -> "testuser");
+    registry.add("spring.rabbitmq.password", () -> "testpass");
   }
 
   @Test
   void contextLoads() {
+    // 단순 컨텍스트 로딩 테스트
   }
 }
-

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,3 @@
 spring:
-  autoconfigure:
-    exclude: org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
   main:
     allow-bean-definition-overriding: true


### PR DESCRIPTION
- build.gradle에 testcontainers-rabbitmq 의존성 추가
- AlgoduckApplicationTests에 RabbitMQContainer 설정 및 프로퍼티 동적 주입
- application-test.yml에서 RabbitAutoConfiguration exclude 제거
- CI 및 로컬 환경 모두에서 통합 테스트 가능하도록 개선