### PR TITLE
[test] 테스트 환경에서 RabbitMQ SSL 비활성화 설정 추가

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,6 @@
 spring:
+  rabbitmq:
+    ssl:
+      enabled: false
   main:
     allow-bean-definition-overriding: true


### PR DESCRIPTION
- application-test.yml에 `spring.rabbitmq.ssl.enabled: false` 설정 추가
- Testcontainers로 구동되는 RabbitMQ 컨테이너가 SSL을 사용하지 않기 때문에 테스트 환경에서 SSL 연결 오류 방지를 위해 적용