### PR TITLE
[test] RabbitMQ Testcontainers 환경에서 SSL 연결 비활성화 설정 추가

### DIFF
--- a/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
+++ b/src/test/java/com/koreii/algoduck/AlgoduckApplicationTests.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.config.TestMockConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
@@ -11,6 +12,7 @@ import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@ActiveProfiles("test")
 @Testcontainers
 @SpringBootTest(
     properties = {
@@ -46,7 +48,9 @@ class AlgoduckApplicationTests {
     registry.add("spring.rabbitmq.port", () -> rabbitMQ.getMappedPort(5672));
     registry.add("spring.rabbitmq.username", () -> "testuser");
     registry.add("spring.rabbitmq.password", () -> "testpass");
+    registry.add("spring.rabbitmq.ssl.enabled", () -> false); // ← 이 줄 추가
   }
+
 
   @Test
   void contextLoads() {


### PR DESCRIPTION
- AlgoduckApplicationTests에 @ActiveProfiles("test") 추가하여 테스트 프로파일 설정 적용
- RabbitMQContainer 설정 시 SSL 연결 시도를 방지하기 위해 spring.rabbitmq.ssl.enabled=false 등록