### PR TITLE
[config] RabbitMQ SSL 비활성화 및 연결 포트 5671 → 5672로 변경

### DIFF
--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -36,11 +36,11 @@ spring:
 
   rabbitmq:
     host: ${JUDGE_QUEUE_DOMAIN_NAME}
-    port: 5671
+    port: 5672
     username: ${JUDGE_QUEUE_USERNAME}
     password: ${JUDGE_QUEUE_PASSWORD}
     ssl:
-      enabled: true
+      enabled: false
       algorithm: TLSv1.2
 
 rabbitmq:


### PR DESCRIPTION
- Spring Boot에서 SSL 없이 RabbitMQ 접속하도록 설정 변경
- application.yml.template 수정