### PR TITLE
[feat] Dockerfile에 JMX 옵션 추가 및 ENTRYPOINT 포맷 개선

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,13 @@ COPY .env /app/.env
 RUN echo "PS1='[\\u@\\h \\w]# '" >> /root/.bashrc
 
 # 애플리케이션 실행
-ENTRYPOINT ["java",
-  "-Dcom.sun.management.jmxremote",
-  "-Dcom.sun.management.jmxremote.port=9010",
-  "-Dcom.sun.management.jmxremote.local.only=false",
-  "-Dcom.sun.management.jmxremote.authenticate=false",
-  "-Dcom.sun.management.jmxremote.ssl=false",
-  "-Djava.rmi.server.hostname=127.0.0.1",
-  "-jar", "app.jar"]
+ENTRYPOINT [    \
+  "java",   \
+  "-Dcom.sun.management.jmxremote", \
+  "-Dcom.sun.management.jmxremote.port=9010",   \
+  "-Dcom.sun.management.jmxremote.local.only=false",    \
+  "-Dcom.sun.management.jmxremote.authenticate=false",  \
+  "-Dcom.sun.management.jmxremote.ssl=false",   \
+  "-Djava.rmi.server.hostname=127.0.0.1",   \
+  "-jar", "app.jar" \
+  ]


### PR DESCRIPTION
- JMX를 통한 JVM 모니터링을 위해 Java 실행 시 JMX 관련 옵션 추가
- Netdata, VisualVM 등 외부 툴과의 연동을 위한 포트 및 인증 설정 포함
- ENTRYPOINT 구문을 가독성 좋게 JSON 배열 형태로 줄바꿈 처리