### PR TITLE
[bugfix] JMX 모니터링을 위한 RMI 호스트 IP 설정 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ ENTRYPOINT [    \
   "-Dcom.sun.management.jmxremote.local.only=false",    \
   "-Dcom.sun.management.jmxremote.authenticate=false",  \
   "-Dcom.sun.management.jmxremote.ssl=false",   \
-  "-Djava.rmi.server.hostname=127.0.0.1",   \
+  "-Djava.rmi.server.hostname=172.17.0.2",   \
   "-jar", "app.jar" \
   ]


### PR DESCRIPTION
- Netdata에서 JVM 메트릭 수집 가능하도록 java.rmi.server.hostname을 127.0.0.1 → 컨테이너 내부 IP(172.18.0.2)로 변경
- JMX Stub가 Netdata에 올바른 주소를 반환하도록 설정