### PR TITLE
[bugfix] jmx_exporter jar 파일명 명시적으로 수정하여 JVM 메트릭 노출 설정 반영

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ RUN echo "PS1='[\\u@\\h \\w]# '" >> /root/.bashrc
 # 애플리케이션 실행
 ENTRYPOINT [    \
   "java",   \
-  "-javaagent:/app/jmx_prometheus_javaagent.jar=9404:/app/jmx_exporter_config.yml", \
+  "-javaagent:/app/jmx_prometheus_javaagent-0.20.0.jar=9404:/app/jmx_exporter_config.yml", \
   "-jar", "app.jar" \
 ]


### PR DESCRIPTION
- ENTRYPOINT에서 -javaagent 경로를 jmx_prometheus_javaagent-0.20.0.jar로 정확히 지정
- Netdata가 Prometheus exporter로부터 JVM 메트릭 수집 가능하도록 설정 명확화