### PR TITLE
[bugfix]  JMX Exporter jar 경로 수정: 정확한 파일명으로 명시하여 복사

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG JAR_FILE=build/libs/algoduck-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
 
 # Prometheus JMX Exporter 파일 복사
-COPY jmx_prometheus_javaagent.jar /app/
+COPY jmx_prometheus_javaagent-0.20.0.jar /app/
 COPY jmx_exporter_config.yml /app/
 
 # 설정 파일 복사


### PR DESCRIPTION
- jmx_prometheus_javaagent.jar → jmx_prometheus_javaagent-0.20.0.jar로 수정
- Dockerfile 복사 경로와 ENTRYPOINT 옵션 간 불일치 해결