### PR TITLE
[bugfix] GitHub Actions: JMX Exporter 관련 파일 누락 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,6 +98,8 @@ jobs:
             docker-compose.yml,
             .env,
             src/main/resources/application.yml
+            jmx_prometheus_javaagent-0.20.0.jar,
+            jmx_exporter_config.yml
           target: "~/algoduck"
 
       - name: Run Spring app on EC2


### PR DESCRIPTION
- jmx_prometheus_javaagent-0.20.0.jar, jmx_exporter_config.yml 파일을 EC2에 복사되도록 scp-action의 source 목록에 추가
- Dockerfile에서 COPY 명령 실패 원인을 해결하기 위함
- Prometheus에서 JVM 메트릭을 수집 가능하게 하려는 목적