### PR TITLE
[bugfix] Java Agent 모드에서 JMX Exporter 설정 오류 수정

### DIFF
--- a/jmx_exporter_config.yml
+++ b/jmx_exporter_config.yml
@@ -1,9 +1,8 @@
 startDelaySeconds: 0
-hostPort: 127.0.0.1:9404
-ssl: false
-username: ""
-password: ""
 lowercaseOutputName: true
 lowercaseOutputLabelNames: true
 rules:
-  - pattern: '.*'
+  - pattern: 'java.lang<type=Memory><HeapMemoryUsage>committed'
+    name: jvm_memory_committed_bytes
+    type: GAUGE
+    help: Committed heap memory in bytes


### PR DESCRIPTION
- jmx_exporter_config.yml 내 hostPort, ssl, username, password 등 원격 JVM 모니터링 전용 필드 제거
- JMX Exporter를 javaagent 모드로 내장 JVM 모니터링에 사용하므로 위 필드 설정 시 실행 중 SEVERE 오류 발생
- rules 설정을 간단한 heap 메모리 모니터링 패턴으로 교체하여 테스트 가능하도록 구성
- 해당 수정으로 애플리케이션이 정상적으로 기동되고 Prometheus에서 JVM 지표 수집 가능해짐