### PR TITLE
[feat] Grafana 및 Prometheus 서비스 실행 위해 전체 docker-compose up 적용

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,8 @@ jobs:
             docker rm algoduck || true
 
             echo "🚀 Spring 앱 컨테이너 빌드 및 실행"
-            docker-compose up -d --build app
+            docker-compose build app
+            docker-compose up -d
 
             echo "🧼 빌드 후 민감한 설정 파일 삭제"
             rm -f .env src/main/resources/application.yml


### PR DESCRIPTION
- 기존에는 'app' 서비스만 실행되어 Grafana 미실행 문제 발생
- docker-compose up -d 로 전체 서비스(app, prometheus, grafana) 기동되도록 수정
- docker-compose build app 로 앱만 빌드해 빌드 효율성 유지