### PR TITLE
[chore] Prometheus 메트릭 수집을 위한 Gradle 및 application.yml 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
 	//	message queue
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+	//	prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -84,13 +84,14 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics,prometheus
+        include: "*"
   endpoint:
-    health:
-      show-details: always
-  metrics:
-    enable:
-      all: true
+    prometheus:
+      enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
 server:
   servlet:


### PR DESCRIPTION
- micrometer-registry-prometheus 의존성 추가 (build.gradle)
- 모든 actuator endpoint 노출 및 prometheus endpoint 활성화
- prometheus.metrics.export.enabled 설정 추가로 최신 방식 적용