### PR TITLE
[chore] GitHub Actions 배포 시 Scouter Agent 디렉토리 EC2로 전송되도록 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,7 +101,8 @@ jobs:
             Dockerfile,
             docker-compose.yml,
             .env,
-            src/main/resources/application.yml
+            src/main/resources/application.yml,
+            scouter-agent.java
           target: "~/algoduck"
 
       - name: Run Spring app on EC2


### PR DESCRIPTION
- scouter-agent.java 디렉토리를 deploy.yml의 rsync 대상에 포함
- EC2에서 Dockerfile 빌드 시 COPY 명령 실패 방지