### PR TITLE
[bugfix] Scouter Agent 설정 줄바꿈 문제 수정으로 obj_name 파싱 오류 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ ENV SCOUTER_OBJ_NAME=algoduck_was
 # 애플리케이션 실행
 ENTRYPOINT ["/bin/bash", "-c", "\
   set -a && source /app/.env && set +a && \
-  echo scouter.server.addr=$SCOUTER_SERVER_ADDR > /scouter-agent/conf/scouter.conf && \
-  echo obj_name=$SCOUTER_OBJ_NAME >> /scouter-agent/conf/scouter.conf && \
+  printf 'scouter.server.addr=%s\n' \"$SCOUTER_SERVER_ADDR\" > /scouter-agent/conf/scouter.conf && \
+  printf 'obj_name=%s\n' \"$SCOUTER_OBJ_NAME\" >> /scouter-agent/conf/scouter.conf && \
   java -javaagent:/scouter-agent/scouter.agent.jar \
   -Dscouter.config=/scouter-agent/conf/scouter.conf \
   -jar /app/app.jar"]


### PR DESCRIPTION
- Dockerfile의 ENTRYPOINT에서 echo 대신 printf 사용
- scouter.conf가 잘못된 형식으로 생성되던 문제 해결
- obj_name에 쉘 프롬프트 문자열이 붙는 현상 방지