### PR TITLE
[feat] scouter.conf를 .env 기반으로 동적 설정되도록 Dockerfile 및 conf 파일 개선

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,15 @@ COPY .env /app/.env
 # 보기 좋은 PS1 설정
 RUN echo "PS1='[\\u@\\h \\w]# '" >> /root/.bashrc
 
-# Scouter 환경변수 기대값
-ENV SCOUTER_SERVER_ADDR=127.0.0.1
-ENV SCOUTER_OBJ_NAME=algoduck_was
-
 # 애플리케이션 실행
 ENTRYPOINT ["/bin/bash", "-c", "\
   set -a && source /app/.env && set +a && \
-  printf 'scouter.server.addr=%s\n' \"$SCOUTER_SERVER_ADDR\" > /scouter-agent/conf/scouter.conf && \
-  printf 'obj_name=%s\n' \"$SCOUTER_OBJ_NAME\" >> /scouter-agent/conf/scouter.conf && \
+  grep -q '^scouter.server.addr=' /scouter-agent/conf/scouter.conf && \
+    sed -i \"s|^scouter.server.addr=.*|scouter.server.addr=$SCOUTER_SERVER_ADDR|\" /scouter-agent/conf/scouter.conf || \
+    echo \"scouter.server.addr=$SCOUTER_SERVER_ADDR\" >> /scouter-agent/conf/scouter.conf && \
+  grep -q '^obj_name=' /scouter-agent/conf/scouter.conf && \
+    sed -i \"s|^obj_name=.*|obj_name=$SCOUTER_OBJ_NAME|\" /scouter-agent/conf/scouter.conf || \
+    echo \"obj_name=$SCOUTER_OBJ_NAME\" >> /scouter-agent/conf/scouter.conf && \
   java -javaagent:/scouter-agent/scouter.agent.jar \
   -Dscouter.config=/scouter-agent/conf/scouter.conf \
   -jar /app/app.jar"]

--- a/scouter-agent.java/conf/scouter.conf
+++ b/scouter-agent.java/conf/scouter.conf
@@ -11,8 +11,8 @@
 #hook_exception_handler_method_patterns=my.AbstractAPIController.fallbackHandler,my.ApiExceptionLoggingFilter.handleNotFoundErrorResponse
 #hook_exception_hanlder_exclude_class_patterns=exception.BizException
 
-scouter.server.addr=52.78.58.71
-obj_name=algoduck_was
+scouter.server.addr=${SCOUTER_SERVER_ADDR}
+obj_name=${SCOUTER_OBJ_NAME}
 
 # HTTP 요청 추적 대상
 hook_method_patterns=com.algoduck.*Controller.*,com.algoduck.*Service.*,com.algoduck.*Repository.*


### PR DESCRIPTION
- Dockerfile의 ENTRYPOINT에서 sed 명령어를 사용해 scouter.server.addr, obj_name 항목만 .env 값을 반영
- scouter-agent.java/conf/scouter.conf 내부 기본값을 ${변수} 형태로 유지하여 IntelliJ 상에서도 변수 명시
- 기존 printf 기반 덮어쓰기에서 sed 기반 치환으로 변경하여 나머지 설정 보존