### PR TITLE
[config] Scouter 연동을 위한 network_mode: host 설정 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
+    network_mode: host
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://${EC2_DB_HOST}:3306/${DB_NAME}?serverTimezone=Asia/Seoul
       SPRING_DATASOURCE_USERNAME: ${DB_USER_NAME}


### PR DESCRIPTION
- docker-compose.yml에서 ports 대신 network_mode: host 설정으로 변경
- Scouter Agent가 UDP를 통해 Scouter Server와 직접 통신 가능하도록 조정