### PR TITLE
[test] 대량 제출 테스트를 'stress' 태그로 분리하여 기본 테스트 실행에서 제외

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,5 +60,11 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+	useJUnitPlatform() {}
+}
+
+test {
+	useJUnitPlatform {
+		excludeTags 'stress'
+	}
 }

--- a/src/test/java/com/koreii/algoduck/submission/controller/TestSubmissionControllerTest.java
+++ b/src/test/java/com/koreii/algoduck/submission/controller/TestSubmissionControllerTest.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.base.dto.response.ApiResponse;
 import com.koreii.algoduck.submission.dto.request.SubmissionRequestDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -29,6 +30,7 @@ class TestSubmissionControllerTest {
   private TestRestTemplate restTemplate;
 
   @Test
+  @Tag("stress")
   void simulateMassiveMaliciousSubmissionsWithResultCheck() throws InterruptedException {
     int totalSubmissions = 100;
 
@@ -92,6 +94,7 @@ class TestSubmissionControllerTest {
   }
 
   @Test
+  @Tag("stress")
   void simulateConcurrentMaliciousSubmissionsWithDelayedResultCheck() throws InterruptedException {
     int totalSubmissions = 1000;
     List<Long> submissionIds = new ArrayList<>();


### PR DESCRIPTION
- simulateMassiveMaliciousSubmissionsWithResultCheck(), simulateConcurrentMaliciousSubmissionsWithDelayedResultCheck()에 @Tag("stress") 추가
- build.gradle에 'stress' 태그 테스트를 제외하는 설정 추가
  - 기본 테스트 실행 시 대량 요청 테스트는 실행되지 않도록 설정
  - 로컬에서는 필요 시 명시적으로 실행 가능: `./gradlew test --tests * --include-tag stress`