### PR TITLE
[config] Swagger 요청 주소 명시하여 localhost로의 잘못된 요청 방지

### DIFF
--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -76,6 +76,7 @@ springdoc:
   api-docs:
     path: /api-docs
   swagger-ui:
+    url: https://algoduck.duckdns.org/api-docs
     path: /swagger-ui.html
     operationsSorter: alpha
     defaultModelsExpandDepth: -1


### PR DESCRIPTION
- springdoc.swagger-ui.url 설정 추가: Swagger UI에서 API 요청 시 기본 주소를 localhost가 아닌 외부 도메인으로 명확히 지정
- 이전까지는 swagger-ui에서 요청이 http://localhost:8080 으로 잘못 전송되어 CORS 오류 발생
- url: https://algoduck.duckdns.org/api-docs 로 명시하여 외부 도메인 기반 요청으로 전환