### PR TITLE
[bugfix] 로그아웃 시 SecurityContext도 함께 정리되도록 수정

### DIFF
--- a/src/main/java/com/koreii/algoduck/member/service/SessionLoginServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/member/service/SessionLoginServiceImpl.java
@@ -8,7 +8,10 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Service;
 
 import static com.koreii.algoduck.util.constants.Constants.LOGIN_MEMBER;
@@ -38,9 +41,17 @@ public class SessionLoginServiceImpl implements LoginService {
   }
 
   public void logout(HttpServletRequest request) {
-    HttpSession session = request.getSession(false);
-    if (session != null) {
-      session.invalidate();
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    log.info("authentication = {}", authentication);
+
+    if (authentication != null) {
+      new SecurityContextLogoutHandler().logout(request, null, authentication);
+    } else {
+      HttpSession session = request.getSession(false);
+      if (session != null) {
+        session.invalidate();
+      }
+      SecurityContextHolder.clearContext();
     }
   }
 }


### PR DESCRIPTION
- 기존에는 HttpSession만 무효화하여 Spring Security의 SecurityContext는 정리되지 않았음
- SecurityContextLogoutHandler를 사용하여 인증 객체(Authentication)까지 명시적으로 제거
- authentication이 null일 경우를 대비해 fallback으로 session 무효화 및 SecurityContext 초기화 처리
- 로그아웃 후에도 @AuthenticationPrincipal이 null이 되지 않는 문제 해결