### PR TITLE
[refactor] RabbitMQ 큐 이름을 환경변수로 설정 가능하도록 변경

### DIFF
--- a/src/main/resources/application.yml.template
+++ b/src/main/resources/application.yml.template
@@ -48,9 +48,9 @@ spring:
 
 rabbitmq:
   queue:
-    request: judge-request
-    progress: judge-progress
-    result: judge-result
+    request: ${JUDGE_QUEUE_REQUEST_QUEUE}
+    progress: ${JUDGE_QUEUE_PROGRESS_QUEUE}
+    result: ${JUDGE_QUEUE_RESULT_QUEUE}
 
 logging:
   file:


### PR DESCRIPTION
- application.yml.template에서 하드코딩된 큐 이름(judge-request 등)을 제거
- JUDGE_QUEUE_REQUEST_QUEUE, JUDGE_QUEUE_PROGRESS_QUEUE, JUDGE_QUEUE_RESULT_QUEUE 환경변수로 설정 가능하도록 수정
- 배포 환경에 따라 큐 이름 유연하게 변경 가능