### PR TITLE
[test] 테스트 환경에서 RabbitMQ 리스너 자동 시작 비활성화

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,5 +1,10 @@
 spring:
   rabbitmq:
+    listener:
+      simple:
+        auto-startup: false
+      direct:
+        auto-startup: false
     ssl:
       enabled: false
   main:


### PR DESCRIPTION
- application-test.yml에 simple/direct 리스너 auto-startup: false 설정 추가
- CI 환경에서 RabbitMQ 브로커 미구동 시 @RabbitListener로 인한 컨텍스트 로드 실패 방지