### PR TITLE
[refactor] 제출 검색 기능을 언어 문자열 기반에서 언어 버전 ID 기반으로 리팩터링

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
+++ b/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
@@ -81,7 +81,7 @@ public class SubmissionController extends BaseApiController {
       @RequestParam(required = false) String loginId,
       @RequestParam(required = false) Long problemNumber,
       @RequestParam(required = false) String status,
-      @RequestParam(required = false) String language,
+      @RequestParam(required = false) List<Long> languageVersionIds,
       @RequestParam(required = false) Long submissionId,
       @RequestParam(required = false) Long lastSeenId,
       @RequestParam(required = false) Long firstSeenId,
@@ -89,7 +89,7 @@ public class SubmissionController extends BaseApiController {
   ) {
     PageResponse<SubmissionResponseDto> page;
 
-    boolean noSearchConditions = loginId == null && problemNumber == null && status == null && language == null && submissionId == null;
+    boolean noSearchConditions = loginId == null && problemNumber == null && status == null && languageVersionIds == null && submissionId == null;
 
     if (noSearchConditions) {
       // getPage()를 직접 호출하지 말고, 그 내부에서 쓰는 service 메서드 호출
@@ -109,11 +109,11 @@ public class SubmissionController extends BaseApiController {
 
     //  나머지 조건 조합 검색
     if (lastSeenId == null && firstSeenId == null) { //  첫 페이지
-      page = submissionService.searchSubmissions(loginId, problemNumber, status, language, null, null, size);
+      page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, null, null, size);
     } else if (lastSeenId != null) {
-      page = submissionService.searchSubmissions(loginId, problemNumber, status, language, lastSeenId, null, size);
+      page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, lastSeenId, null, size);
     } else {
-      page = submissionService.searchSubmissions(loginId, problemNumber, status, language, null, firstSeenId, size);
+      page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, null, firstSeenId, size);
     }
 
     return ResponseEntity.ok(ApiResponse.success(page));

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepository.java
@@ -7,6 +7,8 @@ import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import com.koreii.algoduck.submission.entity.Submission;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface SubmissionRepository {
   Submission saveSubmission(SubmissionSaveRequestDto submissionSaveRequestDto);
@@ -21,7 +23,7 @@ public interface SubmissionRepository {
 
   PageResponse<SubmissionResponseDto> findPrevPage(Long firstSeenId, int pageSize);
 
-  PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, String language, Long lastSeenId, Long firstSeenId, int pageSize);
+  PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize);
 
   long countByMemberId(Long memberId);
 

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -131,18 +131,24 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       String loginId,
       Long problemNumber,
       String status,
-      String language,
+      List<Long> languageVersionIds,
       Long lastSeenId,
       Long firstSeenId,
       int pageSize
   ) {
-    // 1️기본 쿼리 시작
+    log.info("searchSubmissions ");
+    log.info("loginId = {}", loginId);
+    log.info("problemNumber = {}", problemNumber);
+    log.info("status = {}", status);
+    log.info("languageVersionIds = {}", languageVersionIds);
+
+    // 기본 쿼리 시작
     StringBuilder jpql = new StringBuilder(
         "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) FROM Submission s WHERE 1=1"
     );
     StringBuilder countJpql = new StringBuilder("SELECT COUNT(s) FROM Submission s WHERE 1=1");
 
-    // 2️동적 조건 추가
+    // 동적 조건 추가
     if (loginId != null) {
       jpql.append(" AND s.member.loginId = :loginId");
       countJpql.append(" AND s.member.loginId = :loginId");
@@ -155,12 +161,12 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       jpql.append(" AND s.status = :status");
       countJpql.append(" AND s.status = :status");
     }
-    if (language != null) {
-      jpql.append(" AND s.language = :language");
-      countJpql.append(" AND s.language = :language");
+    if (languageVersionIds != null && !languageVersionIds.isEmpty()) {
+      jpql.append(" AND s.version.versionId IN :languageVersionIds");
+      countJpql.append(" AND s.version.versionId IN :languageVersionIds");
     }
 
-    // 3️커서 기반 조건 (submissionId 기준)
+    // 커서 기반 조건 (submissionId 기준)
     if (lastSeenId != null) {
       jpql.append(" AND s.id < :lastSeenId");
       countJpql.append(" AND s.id < :lastSeenId");
@@ -170,14 +176,14 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       countJpql.append(" AND s.id > :firstSeenId");
     }
 
-    // 4️정렬 (내림차순 = 최신순)
+    // 정렬 (내림차순 = 최신순)
     jpql.append(" ORDER BY s.id DESC");
 
-    // 5️TypedQuery 생성
+    // TypedQuery 생성
     TypedQuery<SubmissionResponseDto> query = entityManager.createQuery(jpql.toString(), SubmissionResponseDto.class);
     TypedQuery<Long> countQuery = entityManager.createQuery(countJpql.toString(), Long.class);
 
-    // 6️파라미터 바인딩
+    // 파라미터 바인딩
     if (loginId != null) {
       query.setParameter("loginId", loginId);
       countQuery.setParameter("loginId", loginId);
@@ -190,9 +196,9 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       query.setParameter("status", Status.valueOf(status));
       countQuery.setParameter("status", Status.valueOf(status));
     }
-    if (language != null) {
-      query.setParameter("language", language);
-      countQuery.setParameter("language", language);
+    if (languageVersionIds != null) {
+      query.setParameter("languageVersionIds", languageVersionIds);
+      countQuery.setParameter("languageVersionIds", languageVersionIds);
     }
     if (lastSeenId != null) {
       query.setParameter("lastSeenId", lastSeenId);

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
@@ -6,6 +6,8 @@ import com.koreii.algoduck.submission.dto.request.SubmissionUpdateRequestDto;
 import com.koreii.algoduck.submission.dto.response.SubmissionResponseDto;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public interface SubmissionService {
   SubmissionResponseDto submit(SubmissionRequestDto submissionRequestDto);
@@ -26,7 +28,7 @@ public interface SubmissionService {
 
   PageResponse<SubmissionResponseDto> getPrevPageByMemberId(Long memberId, Long firstSeenId, int pageSize);
 
-  PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, String language, Long lastSeenId, Long firstSeenId, int pageSize);
+  PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize);
 
   String getCode(Long submissionId);
 }

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 @Service
@@ -186,9 +187,9 @@ public class SubmissionServiceImpl implements SubmissionService {
   }
 
   @Override
-  public PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, String language, Long lastSeenId, Long firstSeenId, int pageSize) {
+  public PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize) {
     // Repository에 복합 검색 위임
-    return submissionRepository.searchSubmissions(loginId, problemNumber, status, language, lastSeenId, firstSeenId, pageSize);
+    return submissionRepository.searchSubmissions(loginId, problemNumber, status, languageVersionIds, lastSeenId, firstSeenId, pageSize);
   }
 
   @Override


### PR DESCRIPTION
- SubmissionController
  - 검색 파라미터 language → languageVersionIds(List<Long>)로 변경
  - 조건 없는 요청(noSearchConditions) 판단 로직 수정

- SubmissionService / SubmissionRepository
  - 메서드 시그니처 변경: language → languageVersionIds
  - ServiceImpl, RepositoryJpaImpl 전반 수정

- SubmissionRepositoryJpaImpl
  - JPQL 수정: s.language → s.version.versionId IN :languageVersionIds
  - versionId 리스트 기반 검색 지원 및 파라미터 바인딩 로직 추가
  - 로그 출력 강화 (검색 조건 출력)

- 다중 언어 버전(예: Java 8/11/17 등)을 포함한 복합 검색이 가능하도록 구조 확장