### PR TITLE
[bugfix] Submission 엔티티의 잘못된 id 참조로 인한 조회 오류 수정 및 커서 로직 복구

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
+++ b/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
@@ -89,15 +89,12 @@ public class SubmissionController extends BaseApiController {
   ) {
     PageResponse<SubmissionResponseDto> page;
 
-    boolean noSearchConditions = loginId == null && problemNumber == null && status == null && languageVersionIds == null && submissionId == null;
+    boolean noSearchConditions =
+        loginId == null && problemNumber == null && status == null &&
+            (languageVersionIds == null || languageVersionIds.isEmpty()) &&
+            submissionId == null;
 
-    if (noSearchConditions) {
-      // getPage()를 직접 호출하지 말고, 그 내부에서 쓰는 service 메서드 호출
-      PageResponse<SubmissionResponseDto> firstPage = submissionService.getFirstPage(size);
-      return ResponseEntity.ok(ApiResponse.success(firstPage));
-    }
-
-    //  제출 번호로 단건 조회
+    // ① 단건 조회 (submissionId)
     if (submissionId != null) {
       SubmissionResponseDto submissionResponseDto = submissionService.findBySubmissionId(submissionId);
       List<SubmissionResponseDto> list = submissionResponseDto == null
@@ -107,17 +104,30 @@ public class SubmissionController extends BaseApiController {
       return ResponseEntity.ok(ApiResponse.success(page));
     }
 
-    //  나머지 조건 조합 검색
-    if (lastSeenId == null && firstSeenId == null) { //  첫 페이지
+    // ② 조건 없는 전체 조회 (커서 기반 포함)
+    if (noSearchConditions) {
+      if (lastSeenId == null && firstSeenId == null) {
+        page = submissionService.getFirstPage(size);
+      } else if (lastSeenId != null) {
+        page = submissionService.getNextPage(lastSeenId, size);
+      } else {
+        page = submissionService.getPrevPage(firstSeenId, size);
+      }
+      return ResponseEntity.ok(ApiResponse.success(page));
+    }
+
+    // ③ 조건 검색 + 커서 기반
+    if (lastSeenId == null && firstSeenId == null) { // 첫 페이지
       page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, null, null, size);
-    } else if (lastSeenId != null) {
+    } else if (lastSeenId != null) { // 다음 페이지
       page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, lastSeenId, null, size);
-    } else {
+    } else { // 이전 페이지
       page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, null, firstSeenId, size);
     }
 
     return ResponseEntity.ok(ApiResponse.success(page));
   }
+
 
   @Operation(summary = "회원 제출 목록 페이지 조회", description = "특정 회원의 제출 목록을 커서 기반으로 조회합니다.")
   @GetMapping("/page/member/{memberId}")

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -89,8 +89,8 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
   public PageResponse<SubmissionResponseDto> findNextPage(Long lastSeenId, int pageSize) {
     String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
         "FROM Submission s " +
-        "WHERE (:lastId IS NULL OR s.id < :lastId) " +
-        "ORDER BY s.id DESC";
+        "WHERE (:lastId IS NULL OR s.submissionId < :lastId) " +
+        "ORDER BY s.submissionId DESC";
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("lastId", lastSeenId)
@@ -109,8 +109,8 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
   public PageResponse<SubmissionResponseDto> findPrevPage(Long firstSeenId, int pageSize) {
     String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
         "FROM Submission s " +
-        "WHERE s.id > :firstId " +
-        "ORDER BY s.id ASC";
+        "WHERE s.submissionId > :firstId " +
+        "ORDER BY s.submissionId ASC";
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("firstId", firstSeenId)
@@ -168,16 +168,16 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
 
     // 커서 기반 조건 (submissionId 기준)
     if (lastSeenId != null) {
-      jpql.append(" AND s.id < :lastSeenId");
-      countJpql.append(" AND s.id < :lastSeenId");
+      jpql.append(" AND s.submissionId < :lastSeenId");
+      countJpql.append(" AND s.submissionId < :lastSeenId");
     }
     if (firstSeenId != null) {
-      jpql.append(" AND s.id > :firstSeenId");
-      countJpql.append(" AND s.id > :firstSeenId");
+      jpql.append(" AND s.submissionId > :firstSeenId");
+      countJpql.append(" AND s.submissionId > :firstSeenId");
     }
 
     // 정렬 (내림차순 = 최신순)
-    jpql.append(" ORDER BY s.id DESC");
+    jpql.append(" ORDER BY s.submissionId DESC");
 
     // TypedQuery 생성
     TypedQuery<SubmissionResponseDto> query = entityManager.createQuery(jpql.toString(), SubmissionResponseDto.class);
@@ -245,8 +245,8 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
   public PageResponse<SubmissionResponseDto> findNextPageByMemberId(Long memberId, Long lastSeenId, int pageSize) {
     String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
         "FROM Submission s " +
-        "WHERE s.member.id = :memberId AND (:lastId IS NULL OR s.id < :lastId) " +
-        "ORDER BY s.id DESC";
+        "WHERE s.member.id = :memberId AND (:lastId IS NULL OR s.submissionId < :lastId) " +
+        "ORDER BY s.submissionId DESC";
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("memberId", memberId)
@@ -268,8 +268,8 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
   public PageResponse<SubmissionResponseDto> findPrevPageByMemberId(Long memberId, Long firstSeenId, int pageSize) {
     String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
         "FROM Submission s " +
-        "WHERE s.member.id = :memberId AND s.id > :firstId " +
-        "ORDER BY s.id ASC";
+        "WHERE s.member.id = :memberId AND s.submissionId > :firstId " +
+        "ORDER BY s.submissionId ASC";
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("memberId", memberId)


### PR DESCRIPTION
- SubmissionRepositoryJpaImpl
  - JPQL에서 존재하지 않는 s.id를 s.submissionId로 수정 (Submission 엔티티의 PK)
  - findNextPage, findPrevPage, searchSubmissions 등 커서 기반 메서드 정상화
  - 회원별 페이지 조회(findNextPageByMemberId, findPrevPageByMemberId) 포함 전체 수정

- SubmissionController
  - 단건 조회(submissionId), 전체 조회, 조건 검색 로직 분리 및 가독성 개선
  - languageVersionIds가 비어있을 경우 noSearchConditions로 처리

- 커서 기반 페이지네이션 및 제출 조회 API가 실제 엔티티 구조와 일치하도록 복구