### PR TITLE
[bugfix] 제출 내역 검색을 loginId에서 nickname 기반으로 전환

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
+++ b/src/main/java/com/koreii/algoduck/submission/controller/SubmissionController.java
@@ -78,7 +78,7 @@ public class SubmissionController extends BaseApiController {
   @Operation(summary = "제출 내역 조회", description = "조건에 따른 제출 내역을 커서 기반으로 조회합니다.")
   @GetMapping("/search")
   public ResponseEntity<ApiResponse<PageResponse<SubmissionResponseDto>>> searchSubmission(
-      @RequestParam(required = false) String loginId,
+      @RequestParam(required = false) String nickname,
       @RequestParam(required = false) Long problemNumber,
       @RequestParam(required = false) String status,
       @RequestParam(required = false) List<Long> languageVersionIds,
@@ -90,7 +90,7 @@ public class SubmissionController extends BaseApiController {
     PageResponse<SubmissionResponseDto> page;
 
     boolean noSearchConditions =
-        loginId == null && problemNumber == null && status == null &&
+        nickname == null && problemNumber == null && status == null &&
             (languageVersionIds == null || languageVersionIds.isEmpty()) &&
             submissionId == null;
 
@@ -118,11 +118,11 @@ public class SubmissionController extends BaseApiController {
 
     // ③ 조건 검색 + 커서 기반
     if (lastSeenId == null && firstSeenId == null) { // 첫 페이지
-      page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, null, null, size);
+      page = submissionService.searchSubmissions(nickname, problemNumber, status, languageVersionIds, null, null, size);
     } else if (lastSeenId != null) { // 다음 페이지
-      page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, lastSeenId, null, size);
+      page = submissionService.searchSubmissions(nickname, problemNumber, status, languageVersionIds, lastSeenId, null, size);
     } else { // 이전 페이지
-      page = submissionService.searchSubmissions(loginId, problemNumber, status, languageVersionIds, null, firstSeenId, size);
+      page = submissionService.searchSubmissions(nickname, problemNumber, status, languageVersionIds, null, firstSeenId, size);
     }
 
     return ResponseEntity.ok(ApiResponse.success(page));

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepository.java
@@ -23,7 +23,7 @@ public interface SubmissionRepository {
 
   PageResponse<SubmissionResponseDto> findPrevPage(Long firstSeenId, int pageSize);
 
-  PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize);
+  PageResponse<SubmissionResponseDto> searchSubmissions(String nickname, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize);
 
   long countByMemberId(Long memberId);
 

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -128,7 +128,7 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
 
   @Override
   public PageResponse<SubmissionResponseDto> searchSubmissions(
-      String loginId,
+      String nickname,
       Long problemNumber,
       String status,
       List<Long> languageVersionIds,
@@ -137,7 +137,7 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       int pageSize
   ) {
     log.info("searchSubmissions ");
-    log.info("loginId = {}", loginId);
+    log.info("nickname = {}", nickname);
     log.info("problemNumber = {}", problemNumber);
     log.info("status = {}", status);
     log.info("languageVersionIds = {}", languageVersionIds);
@@ -149,9 +149,9 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     StringBuilder countJpql = new StringBuilder("SELECT COUNT(s) FROM Submission s WHERE 1=1");
 
     // 동적 조건 추가
-    if (loginId != null) {
-      jpql.append(" AND s.member.loginId = :loginId");
-      countJpql.append(" AND s.member.loginId = :loginId");
+    if (nickname != null) {
+      jpql.append(" AND s.member.nickname = :nickname");
+      countJpql.append(" AND s.member.nickname = :nickname");
     }
     if (problemNumber != null) {
       jpql.append(" AND s.problem.problemNumber = :problemNumber");
@@ -184,9 +184,9 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     TypedQuery<Long> countQuery = entityManager.createQuery(countJpql.toString(), Long.class);
 
     // 파라미터 바인딩
-    if (loginId != null) {
-      query.setParameter("loginId", loginId);
-      countQuery.setParameter("loginId", loginId);
+    if (nickname != null) {
+      query.setParameter("nickname", nickname);
+      countQuery.setParameter("nickname", nickname);
     }
     if (problemNumber != null) {
       query.setParameter("problemNumber", problemNumber);

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionService.java
@@ -28,7 +28,7 @@ public interface SubmissionService {
 
   PageResponse<SubmissionResponseDto> getPrevPageByMemberId(Long memberId, Long firstSeenId, int pageSize);
 
-  PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize);
+  PageResponse<SubmissionResponseDto> searchSubmissions(String nickname, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize);
 
   String getCode(Long submissionId);
 }

--- a/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/service/SubmissionServiceImpl.java
@@ -187,9 +187,9 @@ public class SubmissionServiceImpl implements SubmissionService {
   }
 
   @Override
-  public PageResponse<SubmissionResponseDto> searchSubmissions(String loginId, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize) {
+  public PageResponse<SubmissionResponseDto> searchSubmissions(String nickname, Long problemNumber, String status, List<Long> languageVersionIds, Long lastSeenId, Long firstSeenId, int pageSize) {
     // Repository에 복합 검색 위임
-    return submissionRepository.searchSubmissions(loginId, problemNumber, status, languageVersionIds, lastSeenId, firstSeenId, pageSize);
+    return submissionRepository.searchSubmissions(nickname, problemNumber, status, languageVersionIds, lastSeenId, firstSeenId, pageSize);
   }
 
   @Override


### PR DESCRIPTION
- SubmissionController
  - 요청 파라미터를 loginId → nickname으로 변경
  - noSearchConditions 조건에 nickname 반영
  - Service 호출부 파라미터 교체

- SubmissionService / SubmissionRepository
  - 메서드 시그니처를 nickname 기반으로 수정
  - 모든 계층에서 loginId 관련 코드 제거

- SubmissionRepositoryJpaImpl
  - JPQL 수정: s.member.loginId → s.member.nickname
  - 닉네임 파라미터 바인딩 및 로그 출력 수정

- 제출 내역 검색을 회원 닉네임 기준으로 수행하도록 전체 구조 일원화