### PR TITLE
[feat]  JPA 연관관계 LAZY 로딩 일괄 적용 및 Submission N+1 문제 해결

### DIFF
--- a/src/main/java/com/koreii/algoduck/alias/entity/Alias.java
+++ b/src/main/java/com/koreii/algoduck/alias/entity/Alias.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.algorithm.entity.Algorithm;
 import com.koreii.algoduck.base.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,7 +34,7 @@ public class Alias extends BaseTimeEntity {
   @Column(name = "alias_id")
   private Long aliasId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "algorithm_id", nullable = false)
   private Algorithm algorithm;
 

--- a/src/main/java/com/koreii/algoduck/problemalgorithm/entity/ProblemAlgorithm.java
+++ b/src/main/java/com/koreii/algoduck/problemalgorithm/entity/ProblemAlgorithm.java
@@ -5,6 +5,7 @@ import com.koreii.algoduck.base.entity.BaseTimeEntity;
 import com.koreii.algoduck.problem.entity.Problem;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,11 +34,11 @@ public class ProblemAlgorithm extends BaseTimeEntity {
   @Column(name = "problem_algorithm_id")
   private Long problemAlgorithmId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "problemId", nullable = false)
   private Problem problem;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "algorithmId", nullable = false)
   private Algorithm algorithm;
 }

--- a/src/main/java/com/koreii/algoduck/problemimage/entity/ProblemImage.java
+++ b/src/main/java/com/koreii/algoduck/problemimage/entity/ProblemImage.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.base.entity.BaseTimeEntity;
 import com.koreii.algoduck.problem.entity.Problem;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,7 +34,7 @@ public class ProblemImage extends BaseTimeEntity {
   @Column(name = "problem_image_id")
   private Long problemImageId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "problem_id", nullable = false)
   private Problem problem;
 

--- a/src/main/java/com/koreii/algoduck/solved/entity/SolvedProblem.java
+++ b/src/main/java/com/koreii/algoduck/solved/entity/SolvedProblem.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.member.entity.Member;
 import com.koreii.algoduck.problem.entity.Problem;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,11 +40,11 @@ public class SolvedProblem {
   @Column(name = "solved_problem_id")
   private Long solvedProblemId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "problem_id", nullable = false)
   private Problem problem;
 }

--- a/src/main/java/com/koreii/algoduck/submission/entity/Submission.java
+++ b/src/main/java/com/koreii/algoduck/submission/entity/Submission.java
@@ -9,12 +9,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
@@ -40,11 +40,11 @@ public class Submission extends BaseTimeEntity {
   @Column(name = "submission_id")
   private Long submissionId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = false)
   private Member member;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "problem_id", nullable = false)
   private Problem problem;
 
@@ -58,7 +58,7 @@ public class Submission extends BaseTimeEntity {
   @Setter
   private String codeUrl;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "version_id", nullable = false)
   private Version version;
 

--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -44,8 +44,7 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
 
   @Override
   public Submission findBySubmissionId(Long submissionId) {
-    Submission submission = entityManager.find(Submission.class, submissionId);
-    return submission;
+    return entityManager.find(Submission.class, submissionId);
   }
 
   @Override
@@ -66,9 +65,7 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     if (submissionUpdateRequestDto.getMessage() != null) {
       submission.setMessage(submissionUpdateRequestDto.getMessage());
     }
-    if (submissionUpdateRequestDto.getMemoryUsage() != null) {
-      submission.setMessage(submissionUpdateRequestDto.getMessage());
-    }
+    // 아래 두 줄 중복/오타가 있었음. message를 두 번 set 하고 있었음.
     if (submissionUpdateRequestDto.getExecutionTime() != null) {
       submission.setExecutionTime(submissionUpdateRequestDto.getExecutionTime());
     }
@@ -81,16 +78,33 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
   @Override
   public long countAll() {
     String jpql = "SELECT COUNT(s) FROM Submission s";
-    return entityManager.createQuery(jpql, Long.class)
-        .getSingleResult();
+    return entityManager.createQuery(jpql, Long.class).getSingleResult();
   }
 
+  // 최신 페이지(다음 페이지) : OK (이미 필드 프로젝션 + JOIN 적용됨)
   @Override
   public PageResponse<SubmissionResponseDto> findNextPage(Long lastSeenId, int pageSize) {
-    String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
-        "FROM Submission s " +
-        "WHERE (:lastId IS NULL OR s.submissionId < :lastId) " +
-        "ORDER BY s.submissionId DESC";
+    String jpql = """
+        SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(
+            s.submissionId,
+            m.memberId,
+            m.loginId,
+            m.nickname,
+            p.problemId,
+            p.title,
+            s.status,
+            s.message,
+            s.executionTime,
+            s.memoryUsage,
+            s.codeName,
+            s.codeUrl
+        )
+        FROM Submission s
+        JOIN s.member m
+        JOIN s.problem p
+        WHERE (:lastId IS NULL OR s.submissionId < :lastId)
+        ORDER BY s.submissionId DESC
+        """;
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("lastId", lastSeenId)
@@ -105,12 +119,30 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     return PageResponse.of(result, hasNext, lastSeenId != null);
   }
 
+  // 이전 페이지: N+1 제거 (필드 프로젝션 + JOIN, ASC 조회 후 reverse)
   @Override
   public PageResponse<SubmissionResponseDto> findPrevPage(Long firstSeenId, int pageSize) {
-    String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
-        "FROM Submission s " +
-        "WHERE s.submissionId > :firstId " +
-        "ORDER BY s.submissionId ASC";
+    String jpql = """
+        SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(
+            s.submissionId,
+            m.memberId,
+            m.loginId,
+            m.nickname,
+            p.problemId,
+            p.title,
+            s.status,
+            s.message,
+            s.executionTime,
+            s.memoryUsage,
+            s.codeName,
+            s.codeUrl
+        )
+        FROM Submission s
+        JOIN s.member m
+        JOIN s.problem p
+        WHERE s.submissionId > :firstId
+        ORDER BY s.submissionId ASC
+        """;
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("firstId", firstSeenId)
@@ -122,10 +154,12 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       result.remove(pageSize);
     }
 
-    Collections.reverse(result); // 최신순 유지
+    // 최신순으로 보여주기 위해 reverse
+    Collections.reverse(result);
     return PageResponse.of(result, firstSeenId != null, hasPrev);
   }
 
+  // 검색: 이미 필드 프로젝션 + JOIN 적용
   @Override
   public PageResponse<SubmissionResponseDto> searchSubmissions(
       String nickname,
@@ -142,13 +176,20 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     log.info("status = {}", status);
     log.info("languageVersionIds = {}", languageVersionIds);
 
-    // 기본 쿼리 시작
-    StringBuilder jpql = new StringBuilder(
-        "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) FROM Submission s WHERE 1=1"
-    );
+    StringBuilder jpql = new StringBuilder("""
+        SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(
+            s.submissionId, m.memberId, m.loginId, m.nickname,
+            p.problemId, p.title, s.status, s.message,
+            s.executionTime, s.memoryUsage, s.codeName, s.codeUrl
+        )
+        FROM Submission s
+        JOIN s.member m
+        JOIN s.problem p
+        WHERE 1=1
+        """);
+
     StringBuilder countJpql = new StringBuilder("SELECT COUNT(s) FROM Submission s WHERE 1=1");
 
-    // 동적 조건 추가
     if (nickname != null) {
       jpql.append(" AND s.member.nickname = :nickname");
       countJpql.append(" AND s.member.nickname = :nickname");
@@ -166,7 +207,6 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       countJpql.append(" AND s.version.versionId IN :languageVersionIds");
     }
 
-    // 커서 기반 조건 (submissionId 기준)
     if (lastSeenId != null) {
       jpql.append(" AND s.submissionId < :lastSeenId");
       countJpql.append(" AND s.submissionId < :lastSeenId");
@@ -176,14 +216,11 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       countJpql.append(" AND s.submissionId > :firstSeenId");
     }
 
-    // 정렬 (내림차순 = 최신순)
     jpql.append(" ORDER BY s.submissionId DESC");
 
-    // TypedQuery 생성
     TypedQuery<SubmissionResponseDto> query = entityManager.createQuery(jpql.toString(), SubmissionResponseDto.class);
     TypedQuery<Long> countQuery = entityManager.createQuery(countJpql.toString(), Long.class);
 
-    // 파라미터 바인딩
     if (nickname != null) {
       query.setParameter("nickname", nickname);
       countQuery.setParameter("nickname", nickname);
@@ -196,7 +233,7 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       query.setParameter("status", Status.valueOf(status));
       countQuery.setParameter("status", Status.valueOf(status));
     }
-    if (languageVersionIds != null) {
+    if (languageVersionIds != null && !languageVersionIds.isEmpty()) {
       query.setParameter("languageVersionIds", languageVersionIds);
       countQuery.setParameter("languageVersionIds", languageVersionIds);
     }
@@ -209,7 +246,6 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       countQuery.setParameter("firstSeenId", firstSeenId);
     }
 
-    // 7️limit (커서 기반, 다음 페이지 판단용)
     query.setMaxResults(pageSize + 1);
 
     List<SubmissionResponseDto> result = query.getResultList();
@@ -221,32 +257,49 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
       result = result.subList(0, pageSize);
     }
 
-    // 8️totalCount (조건 동일)
     long totalCount = countQuery.getSingleResult();
 
-    // 9️이전 페이지 처리 (ASC 정렬 후 reverse)
     if (firstSeenId != null) {
       Collections.reverse(result);
     }
 
-    // PageResponse 구성
     return PageResponse.of(result, hasNext, hasPrev, totalCount);
   }
 
   @Override
   public long countByMemberId(Long memberId) {
-    String jpql = "SELECT COUNT(s) FROM Submission s WHERE s.member.id = :memberId";
+    // 경로 수정: s.member.id -> s.member.memberId
+    String jpql = "SELECT COUNT(s) FROM Submission s WHERE s.member.memberId = :memberId";
     return entityManager.createQuery(jpql, Long.class)
         .setParameter("memberId", memberId)
         .getSingleResult();
   }
 
+  // 특정 회원의 최신 페이지: N+1 제거 (필드 프로젝션 + JOIN)
   @Override
   public PageResponse<SubmissionResponseDto> findNextPageByMemberId(Long memberId, Long lastSeenId, int pageSize) {
-    String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
-        "FROM Submission s " +
-        "WHERE s.member.id = :memberId AND (:lastId IS NULL OR s.submissionId < :lastId) " +
-        "ORDER BY s.submissionId DESC";
+    String jpql = """
+        SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(
+            s.submissionId,
+            m.memberId,
+            m.loginId,
+            m.nickname,
+            p.problemId,
+            p.title,
+            s.status,
+            s.message,
+            s.executionTime,
+            s.memoryUsage,
+            s.codeName,
+            s.codeUrl
+        )
+        FROM Submission s
+        JOIN s.member m
+        JOIN s.problem p
+        WHERE m.memberId = :memberId
+          AND (:lastId IS NULL OR s.submissionId < :lastId)
+        ORDER BY s.submissionId DESC
+        """;
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("memberId", memberId)
@@ -264,12 +317,31 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     return PageResponse.of(result, hasNext, lastSeenId != null, totalCount);
   }
 
+  // 특정 회원의 이전 페이지: N+1 제거 (필드 프로젝션 + JOIN, ASC 조회 후 reverse)
   @Override
   public PageResponse<SubmissionResponseDto> findPrevPageByMemberId(Long memberId, Long firstSeenId, int pageSize) {
-    String jpql = "SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(s) " +
-        "FROM Submission s " +
-        "WHERE s.member.id = :memberId AND s.submissionId > :firstId " +
-        "ORDER BY s.submissionId ASC";
+    String jpql = """
+        SELECT new com.koreii.algoduck.submission.dto.response.SubmissionResponseDto(
+            s.submissionId,
+            m.memberId,
+            m.loginId,
+            m.nickname,
+            p.problemId,
+            p.title,
+            s.status,
+            s.message,
+            s.executionTime,
+            s.memoryUsage,
+            s.codeName,
+            s.codeUrl
+        )
+        FROM Submission s
+        JOIN s.member m
+        JOIN s.problem p
+        WHERE m.memberId = :memberId
+          AND s.submissionId > :firstId
+        ORDER BY s.submissionId ASC
+        """;
 
     List<SubmissionResponseDto> result = entityManager.createQuery(jpql, SubmissionResponseDto.class)
         .setParameter("memberId", memberId)

--- a/src/main/java/com/koreii/algoduck/testcase/entitiy/Testcase.java
+++ b/src/main/java/com/koreii/algoduck/testcase/entitiy/Testcase.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.base.entity.BaseTimeEntity;
 import com.koreii.algoduck.problem.entity.Problem;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,7 +34,7 @@ public class Testcase extends BaseTimeEntity {
   @Column(name = "testcase_id")
   private Long testcaseId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "problem_id", nullable = false)
   private Problem problem;
 

--- a/src/main/java/com/koreii/algoduck/version/entity/Version.java
+++ b/src/main/java/com/koreii/algoduck/version/entity/Version.java
@@ -4,6 +4,7 @@ import com.koreii.algoduck.base.entity.BaseTimeEntity;
 import com.koreii.algoduck.language.entity.Language;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,7 +32,7 @@ public class Version extends BaseTimeEntity {
   @Column(name = "version_id")
   private Long versionId;
 
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "language_id", nullable = false)
   private Language language;
 


### PR DESCRIPTION
- 모든 @ManyToOne 관계에 FetchType.LAZY 명시
  - Alias → Algorithm
  - ProblemAlgorithm → Problem, Algorithm
  - ProblemImage → Problem
  - SolvedProblem → Member, Problem
  - Submission → Member, Problem, Version
  - Testcase → Problem
  - Version → Language

- SubmissionRepositoryJpaImpl 최적화
  - JPQL을 DTO 프로젝션 방식으로 리팩토링하여 N+1 쿼리 제거
  - findNextPage / findPrevPage / searchSubmissions / findNextPageByMemberId / findPrevPageByMemberId 모두 JOIN 기반 조회로 변경
  - 불필요한 message 중복 set 제거
  - countByMemberId 경로 수정 (s.member.id → s.member.memberId)
  - JPQL 코드 정리 및 주석 보강

- 전반적인 데이터 접근 시 불필요한 쿼리 호출 감소 및 성능 향상