### PR TITLE
[feat] 제출 내역 검색 시 닉네임 부분 일치 및 대소문자 무시 기능 추가

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -190,9 +190,9 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
 
     StringBuilder countJpql = new StringBuilder("SELECT COUNT(s) FROM Submission s WHERE 1=1");
 
-    if (nickname != null) {
-      jpql.append(" AND s.member.nickname = :nickname");
-      countJpql.append(" AND s.member.nickname = :nickname");
+    if (nickname != null && !nickname.isEmpty()) {
+      jpql.append(" AND LOWER(s.member.nickname) LIKE LOWER(CONCAT('%', :nickname, '%'))");
+      countJpql.append(" AND LOWER(s.member.nickname) LIKE LOWER(CONCAT('%', :nickname, '%'))");
     }
     if (problemNumber != null) {
       jpql.append(" AND s.problem.problemNumber = :problemNumber");


### PR DESCRIPTION
- RepositoryJpaImpl
  - 기존 `s.member.nickname = :nickname` 조건을 → `LOWER(s.member.nickname) LIKE LOWER(CONCAT('%', :nickname, '%'))` 로 변경
  - 빈 문자열 검사(`!nickname.isEmpty()`) 추가
  - COUNT 쿼리에도 동일 조건 적용

- 사용자가 닉네임 일부만 입력해도 대소문자 구분 없이 검색 가능하도록 개선