### PR TITLE
[feat] 회원 검색 쿼리를 접두(prefix) 일치 방식으로 최적화

### DIFF
--- a/src/main/java/com/koreii/algoduck/member/repository/MemberRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/member/repository/MemberRepositoryJpaImpl.java
@@ -90,7 +90,7 @@ public class MemberRepositoryJpaImpl implements MemberRepository {
 
   @Override
   public long countWithLoginId(String loginId) {
-    String jpql = "SELECT COUNT(m) FROM Member m WHERE m.loginId LIKE :loginId";
+    String jpql = "SELECT COUNT(m) FROM Member m WHERE m.loginId  LIKE CONCAT(:loginId, '%')";
     return entityManager.createQuery(jpql, Long.class).setParameter("loginId", "%" + loginId + "%").getSingleResult();
   }
 
@@ -99,15 +99,15 @@ public class MemberRepositoryJpaImpl implements MemberRepository {
     log.info("loginId = {}", loginId);
 
     int offset = (pageNumber - 1) * pageSize;
-    String jpql = "SELECT new com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto(m) "
-        + "FROM Member m "
-        + "WHERE m.loginId LIKE :loginId "
-        + "ORDER BY m.solved DESC, m.createdAt ASC";
-
-    log.info("jpql = {}", jpql);
+    String jpql = """
+        SELECT new com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto(m)
+        FROM Member m
+        WHERE m.loginId LIKE CONCAT(:loginId, '%')
+        ORDER BY m.solved DESC, m.createdAt ASC
+        """;
 
     return entityManager.createQuery(jpql, MemberSimpleResponseDto.class)
-        .setParameter("loginId", "%" + loginId + "%")
+        .setParameter("loginId", loginId)
         .setFirstResult(offset)
         .setMaxResults(pageSize)
         .getResultList();
@@ -115,20 +115,24 @@ public class MemberRepositoryJpaImpl implements MemberRepository {
 
   @Override
   public long countWithNickname(String nickname) {
-    String jpql = "SELECT COUNT(m) FROM Member m WHERE m.nickname LIKE :nickname";
-    return entityManager.createQuery(jpql, Long.class).setParameter("nickname", "%" + nickname + "%").getSingleResult();
+    String jpql = "SELECT COUNT(m) FROM Member m WHERE m.nickname LIKE CONCAT(:nickname, '%')";
+    return entityManager.createQuery(jpql, Long.class)
+        .setParameter("nickname", nickname)
+        .getSingleResult();
   }
 
   @Override
   public List<MemberSimpleResponseDto> findWithNickname(String nickname, int pageNumber, int pageSize) {
     int offset = (pageNumber - 1) * pageSize;
-    String jpql = "SELECT new com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto(m) "
-        + "FROM Member m "
-        + "WHERE m.nickname LIKE :nickname "
-        + "ORDER BY m.solved DESC, m.createdAt ASC";
+    String jpql = """
+        SELECT new com.koreii.algoduck.member.dto.response.MemberSimpleResponseDto(m)
+        FROM Member m
+        WHERE m.nickname LIKE CONCAT(:nickname, '%')
+        ORDER BY m.solved DESC, m.createdAt ASC
+        """;
 
     return entityManager.createQuery(jpql, MemberSimpleResponseDto.class)
-        .setParameter("nickname", "%" + nickname + "%")
+        .setParameter("nickname", nickname)
         .setFirstResult(offset)
         .setMaxResults(pageSize)
         .getResultList();


### PR DESCRIPTION
- countWithLoginId / findWithLoginId:
  - 기존 LIKE '%keyword%' → LIKE CONCAT(:loginId, '%')
  - setParameter 시 불필요한 '%' 문자열 제거
  - 인덱스 사용 가능하도록 개선

- countWithNickname / findWithNickname:
  - 동일한 접두 일치 방식 적용
  - JPQL 템플릿 문자열 적용으로 코드 가독성 개선

- 불필요한 Full Scan을 방지하고, 검색 성능 향상 기대