### PR TITLE
[feat] 제출 내역 닉네임 검색을 접두(prefix) 일치 방식으로 최적화

### DIFF
--- a/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
+++ b/src/main/java/com/koreii/algoduck/submission/repository/SubmissionRepositoryJpaImpl.java
@@ -191,8 +191,8 @@ public class SubmissionRepositoryJpaImpl implements SubmissionRepository {
     StringBuilder countJpql = new StringBuilder("SELECT COUNT(s) FROM Submission s WHERE 1=1");
 
     if (nickname != null && !nickname.isEmpty()) {
-      jpql.append(" AND LOWER(s.member.nickname) LIKE LOWER(CONCAT('%', :nickname, '%'))");
-      countJpql.append(" AND LOWER(s.member.nickname) LIKE LOWER(CONCAT('%', :nickname, '%'))");
+      jpql.append(" AND LOWER(s.member.nickname) LIKE LOWER(CONCAT(:nickname, '%'))");
+      countJpql.append(" AND LOWER(s.member.nickname) LIKE LOWER(CONCAT(:nickname, '%'))");
     }
     if (problemNumber != null) {
       jpql.append(" AND s.problem.problemNumber = :problemNumber");


### PR DESCRIPTION
- 기존 LIKE '%nickname%' 조건 제거 → LIKE CONCAT(:nickname, '%')로 변경
- DB 인덱스 활용을 통한 쿼리 성능 향상
- count 쿼리에도 동일한 변경 반영
- 부분 일치(contains)보다 효율적인 prefix match로 개선